### PR TITLE
Adds OpenAPI documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 SERVER_PORT=8080
 URL_BASE=http://localhost:8080
 URL_VERSION_1_0=http://docker02.testingmachine.eu:1003
+URL_SWAGGER=https://swagger.opendatahub.bz.it/?url=https://destinationdata.alpinebits.opendatahub.bz.it/specification.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a reference implementation for an AlpineBits DestinationData server. The server exposes data from the OpenDataHub API in accordance to the AlpineBits format.
 
-However, this application operates only as proxy to forward requests to the dedicated versions of the reference implementation.
+However, the main purpose of this application is to operate as proxy to forward requests to the dedicated versions of the reference implementation.
+
+Additionally, this project also hosts the OpenAPI specification of the reference implementation. For detailed instructions regarding the OpenAPI specification, click [here](./openapi).
 
 ## Table of contents
 

--- a/openapi/.gitignore
+++ b/openapi/.gitignore
@@ -1,0 +1,6 @@
+
+node_modules/
+
+src/specification.json
+src/specification.yml
+

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,0 +1,45 @@
+# AlpineBits DestinationData OpenAPI Specification
+
+This project contains an OpenAPI specification based on the [AlpineBits DestinationData](https://www.alpinebits.org/destinationdata/) standard.
+This project's goal is two-fold: first, to provide an entry point for server and client developers to the AlpineBits DestinationData standard; second, to provide a template for server developers to document their own implementations of the AlpineBits DestinationData standard.
+
+This project is not intended as a replacement of the official documentation of the AlpineBits DestinationData standard, but as a additional resource. This specification, for instance, does not cover the aspects like responsibilities of servers and clients involved in requests.
+
+To access this specification as a live Swagger documentation, visit [https://alpinebits.gitlab.io/destinationdata/tools](https://alpinebits.gitlab.io/destinationdata/tools).
+
+## Modifying the Specification
+
+In order to modify the specification, both in case of improving the specification contained here, and in case of using this project as template for the documentation of your own server, go to the file `src/index.yml`. This file is the "entry point" for the whole specification, which is split in multiple files to enable modularization and reuse. Navigate through `$ref` references to understand how the specification is composed.
+
+For developing the specification, the usage of [Visual Studio Code](https://code.visualstudio.com/) along with the extension [OpenAPI (Swagger) Editor](https://marketplace.visualstudio.com/items?itemName=42Crunch.vscode-openapi) is highly recommended. This extension supports real-time visualization of a Swagger documentation based on the specification. This extension is also able to handle specification split into multiple files.
+
+## Compiling the Specification
+
+Some tools and deployment environments cannot handle OpenAPI specifications that are split into multiple files. Therefore, in order to compile the specification into a single file, run the following command from the project's root (requires NPM and Node):
+
+```bash
+npm install            # run only once to retrieve dependencies
+npm run bundle
+```
+
+This command compiles the file `src/index.yml` and its dependencies into the files `src/specification.json` and `src/specification.yml`.
+
+If you wish to validate your specification to check whether it violates constraints of the OpenAPI specification, you can run the following command:
+
+```bash
+npm run validate
+```
+
+## Hosting a Swagger Page with Docker
+
+If you wish to use Docker to offer this specification as a Swagger interactive documentation, you can run the following command:
+
+```bash
+npm run host
+```
+
+By default, page will be hosted on port `3000`, but this can be easily modified in the `package.json` file.
+
+## Deploying Swagger as a Static Page
+
+Additionally, you can use the contents of the folder `/public` to deploy the project as a static page. In fact, when `npm run bundle` is executed, the all necessary files for this static page are already generated.

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -22,7 +22,7 @@ npm install            # run only once to retrieve dependencies
 npm run bundle
 ```
 
-This command compiles the file `src/index.yml` and its dependencies into the files `src/specification.json` and `src/specification.yml`.
+This command compiles the file `src/index.yml` and its dependencies into the files `src/specification.yml`.
 
 If you wish to validate your specification to check whether it violates constraints of the OpenAPI specification, you can run the following command:
 
@@ -39,7 +39,3 @@ npm run host
 ```
 
 By default, page will be hosted on port `3000`, but this can be easily modified in the `package.json` file.
-
-## Deploying Swagger as a Static Page
-
-Additionally, you can use the contents of the folder `/public` to deploy the project as a static page. In fact, when `npm run bundle` is executed, the all necessary files for this static page are already generated.

--- a/openapi/package-lock.json
+++ b/openapi/package-lock.json
@@ -1,0 +1,845 @@
+{
+  "name": "standard-open-api",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.7.tgz",
+      "integrity": "sha512-QdwOGF1+eeyFh+17v2Tz626WX0nucd1iKOm6JUTUvCZdbolblCOOQCxGrQPY0f7jEhn36PiAWqZnsC2r5vmUWg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="
+    },
+    "@apidevtools/swagger-cli": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-cli/-/swagger-cli-4.0.4.tgz",
+      "integrity": "sha512-hdDT3B6GLVovCsRZYDi3+wMcB1HfetTU20l2DC8zD3iFRNMC6QNAZG5fo/6PYeHWBEv7ri4MvnlKodhNB0nt7g==",
+      "requires": {
+        "@apidevtools/swagger-parser": "^10.0.1",
+        "chalk": "^4.1.0",
+        "js-yaml": "^3.14.0",
+        "yargs": "^15.4.1"
+      }
+    },
+    "@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="
+    },
+    "@apidevtools/swagger-parser": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.2.tgz",
+      "integrity": "sha512-JFxcEyp8RlNHgBCE98nwuTkZT6eNFPc1aosWV6wPcQph72TSEEu1k3baJD4/x1qznU+JiDdz8F5pTwabZh+Dhg==",
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^4.2.3"
+      }
+    },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "optional": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
+      "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.2",
+        "is-string": "^1.0.5",
+        "object-inspect": "^1.9.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+    },
+    "hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-bigint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
+    },
+    "is-boolean-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.0.tgz",
+      "integrity": "sha512-a7Uprx8UtD+HWdyYwnD1+ExtTgqQtD2k/1yJgtXP6wnMm8byhkoTZRl+95LLThpzNZJ5aEvi46cdH+ayMFRwmA==",
+      "requires": {
+        "call-bind": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+    },
+    "is-core-module": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
+      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.3.tgz",
+      "integrity": "sha512-tDpEUInNcy2Yw3lNSepK3Wdw1RnXLcIVienz6Ou631Acl15cJyRWK4dgA1vCmOEgIbtOV0W7MHg+AR2Gdg1NXQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+    },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
+    },
+    "is-regex": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+      "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
+    "load-json-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^4.0.0",
+        "pify": "^3.0.0",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "object-inspect": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
+    "parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "requires": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "requires": {
+        "pify": "^3.0.0"
+      }
+    },
+    "pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA=="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+      "requires": {
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+    },
+    "resolve": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "requires": {
+        "is-core-module": "^2.2.0",
+        "path-parse": "^1.0.6"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg=="
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string-width": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.2.tgz",
+      "integrity": "sha512-/AQFLdYvePENU3W5rgurfWSMU6n+Ww8n/3cUt7E+vPBB/D7YDG8x+qjoFs4M/alR2bW7Qg6xMjVwWUOvuQ0XpQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "validator": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
+      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "requires": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "z-schema": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.3.tgz",
+      "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
+      "requires": {
+        "commander": "^2.7.1",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^12.0.0"
+      }
+    }
+  }
+}

--- a/openapi/package.json
+++ b/openapi/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "standard-open-api",
+  "version": "0.0.1",
+  "engines": {
+    "node": "14.x"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+git@gitlab.com:claudenirmf/standard-open-api.git"
+  },
+  "author": "Tiago Prince Sales <tiago.princesales@unibz.it>",
+  "contributors": [
+    "Claudenir Morais Fonseca <cmoraisfonseca@unibz.it>",
+    "Tiago Prince Sales <tiago.princesales@unibz.it>"
+  ],
+  "bugs": {
+    "url": "https://gitlab.com/claudenirmf/standard-open-api"
+  },
+  "homepage": "https://gitlab.com/claudenirmf/standard-open-api",
+  "scripts": {
+    "bundle": "npm-run-all -s bundle:yaml bundle:json",
+    "bundle:yaml": "swagger-cli bundle src/index.yml -o ./src/specification.yml -t yaml",
+    "bundle:json": "swagger-cli bundle src/index.yml -o ./../src/specification.json -t json",
+    "validate": "swagger-cli validate ./src/specification.yml -t yaml",
+    "host": "docker run -p 3000:8080 -e SWAGGER_JSON=/src/specification.yml -v `pwd`/src:/src swaggerapi/swagger-ui"
+  },
+  "dependencies": {
+    "@apidevtools/swagger-cli": "^4.0.4",
+    "npm-run-all": "^4.1.5"
+  },
+  "devDependencies": {}
+}

--- a/openapi/src/examples/2021-04.json
+++ b/openapi/src/examples/2021-04.json
@@ -1,0 +1,13 @@
+{
+    "links": {
+        "self": "https://example.com/2021-04/",
+        "categories": "https://example.com/2021-04/categories",
+        "events": "https://example.com/2021-04/events",
+        "features": "https://example.com/2021-04/features",
+        "lifts": "https://example.com/2021-04/lifts",
+        "mountainAreas": "https://example.com/2021-04/mountainAreas",
+        "skiSlopes": "https://example.com/2021-04/skiSlopes",
+        "snowparks": "https://example.com/2021-04/snowparks"
+    },
+    "data": null
+}

--- a/openapi/src/examples/agents.categories.json
+++ b/openapi/src/examples/agents.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/agents/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "alpinebits:organization",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Organization"
+        },
+        "namespace": "alpinebits",
+        "resourceTypes": [ "agents" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/alpinebits:organization",
+        "resources": {
+          "agents": "https://example.com/2021-04/agents?filter[categories][any]=alpinebits:organization"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/agents.id.json
+++ b/openapi/src/examples/agents.id.json
@@ -1,0 +1,159 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/agents/1"
+  },
+  "included": null,
+  "data": {
+    "type": "agents",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee...",
+        "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas...",
+        "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions..."
+      },
+      "contactPoints": [
+        {
+          "email": "info@noi.bz.it",
+          "telephone": "+39 0471 066 600",
+          "address": {
+            "street": {
+              "ita": "Piazza Università 1"
+            },
+            "city": {
+              "ita": "Bolzano"
+            },
+            "region": {
+              "ita": "Trentino-Alto Adige"
+            },
+            "country": "IT",
+            "zipcode": "39100",
+            "complement": {
+              "ita": "Ufficio 3.07"
+            },
+            "categories": [
+              "example:main"
+            ]
+          },
+          "availableHours": {
+            "dailySchedules": {
+              "2020-12-23": [
+                {
+                  "opens": "08:00:00",
+                  "closes": "12:00:00"
+                }
+              ],
+              "2020-12-25": null
+            },
+            "weeklySchedules": [
+              {
+                "validFrom": "2020-01-01",
+                "validTo": "2020-12-31",
+                "monday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "tuesday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "wednesday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "thursday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "friday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "saturday": null,
+                "sunday": null
+              }
+            ]
+          }
+        }
+      ],
+      "description": {
+        "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee, al crocevia tra il mondo economico e culturale tedesco e italiano.",
+        "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas an der Schnittstelle zwischen dem deutschsprachigen und italienischen Kultur- und Wirtschaftsraum.",
+        "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions, at the crossroads between the German-speaking and Italian economies and cultures."
+      },
+      "name": {
+        "ita": "Libera Univeristà di Bolzano",
+        "deu": "Freie Universität Bozen",
+        "eng": "Free University of Bozen-Bolzano"
+      },
+      "shortName": {
+        "eng": "Unibz"
+      },
+      "url": "https://www.unibz.it"
+    },
+    "relationships": {
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "alpinebits:organization"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/agents/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/agents/1"
+    }
+  }
+}

--- a/openapi/src/examples/agents.json
+++ b/openapi/src/examples/agents.json
@@ -1,0 +1,169 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/agents?page[number]=2",
+      "prev": "https://example.com/2021-04/agents?page[number]=1",
+      "first": "https://example.com/2021-04/agents?page[number]=1",
+      "last": "https://example.com/2021-04/agents?page[number]=10",
+      "self": "https://example.com/2021-04/agents"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "agents",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee...",
+          "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas...",
+          "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions..."
+        },
+        "contactPoints": [
+          {
+            "email": "info@noi.bz.it",
+            "telephone": "+39 0471 066 600",
+            "address": {
+              "street": {
+                "ita": "Piazza Università 1"
+              },
+              "city": {
+                "ita": "Bolzano"
+              },
+              "region": {
+                "ita": "Trentino-Alto Adige"
+              },
+              "country": "IT",
+              "zipcode": "39100",
+              "complement": {
+                "ita": "Ufficio 3.07"
+              },
+              "categories": [
+                "example:main"
+              ]
+            },
+            "availableHours": {
+              "dailySchedules": {
+                "2020-12-23": [
+                  {
+                    "opens": "08:00:00",
+                    "closes": "12:00:00"
+                  }
+                ],
+                "2020-12-25": null
+              },
+              "weeklySchedules": [
+                {
+                  "validFrom": "2020-01-01",
+                  "validTo": "2020-12-31",
+                  "monday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "tuesday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "wednesday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "thursday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "friday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "saturday": null,
+                  "sunday": null
+                }
+              ]
+            }
+          }
+        ],
+        "description": {
+          "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee, al crocevia tra il mondo economico e culturale tedesco e italiano.",
+          "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas an der Schnittstelle zwischen dem deutschsprachigen und italienischen Kultur- und Wirtschaftsraum.",
+          "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions, at the crossroads between the German-speaking and Italian economies and cultures."
+        },
+        "name": {
+          "ita": "Libera Univeristà di Bolzano",
+          "deu": "Freie Universität Bozen",
+          "eng": "Free University of Bozen-Bolzano"
+        },
+        "shortName": {
+          "eng": "Unibz"
+        },
+        "url": "https://www.unibz.it"
+      },
+      "relationships": {
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:organization"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/agents/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/agents/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/agents.multimediaDescriptions.json
+++ b/openapi/src/examples/agents.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/base.json
+++ b/openapi/src/examples/base.json
@@ -1,0 +1,8 @@
+{
+  "links": {
+    "self": "https://destinationdata.alpinebits.opendatahub.bz.it/",
+    "1.0": "https://destinationdata.alpinebits.opendatahub.bz.it/1.0/",
+    "2021-04": "https://destinationdata.alpinebits.opendatahub.bz.it/2021-04/"
+  },
+  "data": null
+}

--- a/openapi/src/examples/categories.children.json
+++ b/openapi/src/examples/categories.children.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/categories/example:category/children"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:subcategory",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Child Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "events" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:subcategory",
+        "resources": {
+          "events": "https://example.com/2021-04/events?filter[categories][any]=example:subcategory"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/categories.id.json
+++ b/openapi/src/examples/categories.id.json
@@ -1,0 +1,81 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/categories/example:soccerEvent"
+  },
+  "included": null,
+  "data": {
+    "type": "categories",
+    "id": "example:soccerEvent",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2021-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "ita": "Un evento sportivo legato al calcio.",
+        "deu": "Ein Sportereignis, das mit Fußball zu tun hat.",
+        "eng": "A sports event related to soccer."
+      },
+      "description": {
+        "ita": "Un evento sportivo legato al calcio, per esempio una partita di calcio o un incontro con i giocatori.",
+        "deu": "Ein Sportereignis mit Bezug zum Fußball, z. B. ein Fußballspiel oder ein Meet-and-Greet mit Spielern.",
+        "eng": "A sports event related to soccer, for example a soccer match or a meet-and-greet with players."
+      },
+      "name": {
+        "ita": "Evento di Calcio",
+        "deu": "Fußball-Event",
+        "eng": "Soccer Event"
+      },
+      "namespace": "example",
+      "resourceTypes": [ "events" ],
+      "shortName": {
+        "eng": "Soccer Event"
+      },
+      "url": "https://en.wikipedia.org/wiki/Association_football"
+    },
+    "relationships": {
+      "children": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "example:sub19SoccerMatch"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/categories/example:soccerEvent/children"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/categories/example:soccerEvent/multimediaDescriptions"
+        }
+      },
+      "parents": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "schema:SportsEvent"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/categories/example:soccerEvent/parents"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/categories/example:soccerEvent",
+      "resources": {
+        "events": "https://example.com/2021-04/events?filter[categories][any]=example:soccerEvent"
+      }
+    }
+  }
+}

--- a/openapi/src/examples/categories.json
+++ b/openapi/src/examples/categories.json
@@ -1,0 +1,91 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/categories?page[number]=2",
+      "prev": "https://example.com/2021-04/categories?page[number]=1",
+      "first": "https://example.com/2021-04/categories?page[number]=1",
+      "last": "https://example.com/2021-04/categories?page[number]=10",
+      "self": "https://example.com/2021-04/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:soccerEvent",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2021-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "ita": "Un evento sportivo legato al calcio.",
+          "deu": "Ein Sportereignis, das mit Fußball zu tun hat.",
+          "eng": "A sports event related to soccer."
+        },
+        "description": {
+          "ita": "Un evento sportivo legato al calcio, per esempio una partita di calcio o un incontro con i giocatori.",
+          "deu": "Ein Sportereignis mit Bezug zum Fußball, z. B. ein Fußballspiel oder ein Meet-and-Greet mit Spielern.",
+          "eng": "A sports event related to soccer, for example a soccer match or a meet-and-greet with players."
+        },
+        "name": {
+          "ita": "Evento di Calcio",
+          "deu": "Fußball-Event",
+          "eng": "Soccer Event"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "events" ],
+        "shortName": {
+          "eng": "Soccer Event"
+        },
+        "url": "https://en.wikipedia.org/wiki/Association_football"
+      },
+      "relationships": {
+        "children": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example:sub19SoccerMatch"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/categories/example:soccerEvent/children"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/categories/example:soccerEvent/multimediaDescriptions"
+          }
+        },
+        "parents": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "schema:SportsEvent"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/categories/example:soccerEvent/parents"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:soccerEvent",
+        "resources": {
+          "events": "https://example.com/2021-04/events?filter[categories][any]=example:soccerEvent"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/categories.multimediaDescriptions.json
+++ b/openapi/src/examples/categories.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/categories/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/categories.parents.json
+++ b/openapi/src/examples/categories.parents.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/categories/example:category/parents"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:supercategory",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Parent Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "events" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:supercategory",
+        "resources": {
+          "events": "https://example.com/2021-04/events?filter[categories][any]=example:supercategory"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/eventSeries.categories.json
+++ b/openapi/src/examples/eventSeries.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/eventSeries/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:category",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "eventSeries" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:category",
+        "resources": {
+          "eventSeries": "https://example.com/2021-04/eventSeries?filter[categories][any]=example:category"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/eventSeries.editions.json
+++ b/openapi/src/examples/eventSeries.editions.json
@@ -1,0 +1,152 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/eventSeries/1/editions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "events",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "eng": "Südtirol Jazz Festival 2020",
+          "deu": "Südtirol Jazz Festival 2020",
+          "ita": "Südtirol Jazz Festival 2020"
+        },
+        "shortName": {
+          "eng": "Südtirol Jazz Festival 2020"
+        },
+        "description": {
+          "deu": "Beim Südtirol Jazzfestival Alto Adige wagen sich Solisten und Ensembles nicht nur in schwindelerregende musikalische „Höhen“ vor, sondern besteigen, mit ihren Instrumenten im Gepäck, sogar „echte“ Berge und bespielen dabei eine atemberaubende alpine Landschaft. Das Festival selbst beschreitet oft ganz neue Wege: selbstbewusst und sich mitunter über zerklüftete Spalten herantastend, versucht es in neue Klanglandschaften vorzudringen. Mainstream und Konzertsäle sind beim Südtirol Jazzfestival Alto Adige vom Aussterben bedroht...."
+        },
+        "abstract": {
+          "deu": "Das Südtirol Jazzfestival Alto Adige ist ein in Südtirol stattfindendes Musikfestival für Jazz und experimentelle Musik."
+        },
+        "startDate": "2020-06-26T21:00:00+00:00",
+        "endDate": "2020-07-07T23:30:00+00:00",
+        "url": "https://www.suedtiroljazzfestival.com/",
+        "status": "published",
+        "capacity": 1000
+      },
+      "relationships": {
+        "series": {
+          "data": {
+            "type": "eventSeries",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/events/1/eventSeries"
+          }
+        },
+        "publisher": {
+          "data": {
+            "type": "agents",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/events/1/publisher"
+          }
+        },
+        "organizers": {
+          "data": [
+            {
+              "type": "agents",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/organizers"
+          }
+        },
+        "sponsors": {
+          "data": [
+            {
+              "type": "agents",
+              "id": "3"
+            },
+            {
+              "type": "agents",
+              "id": "4"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/sponsors"
+          }
+        },
+        "contributors": {
+          "data": [
+            {
+              "type": "agents",
+              "id": "5"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/contributors"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "schema:MusicEvent"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            },
+            {
+              "type": "mediaObjects",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/multimediaDescriptions"
+          }
+        },
+        "venues": {
+          "data": [
+            {
+              "type": "venues",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/venues"
+          }
+        },
+        "subEvents": {
+          "data": [
+            {
+              "type": "events",
+              "id": "2"
+            },
+            {
+              "type": "events",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/subEvents"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/events/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/eventSeries.id.json
+++ b/openapi/src/examples/eventSeries.id.json
@@ -1,0 +1,77 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/eventSeries/1"
+  },
+  "included": null,
+  "data": {
+    "type": "eventSeries",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "eng": "The Südtirol Jazzfestival Alto Adige was held for the first time in 1982 under the name of “Jazz Summer”..."
+      },
+      "description": {
+        "eng": "The Südtirol Jazzfestival Alto Adige was held for the first time in 1982 under the name of “Jazz Summer”, which went on to become “Jazz & Other”. While in the early years the concerts were played only in Bolzano itself, today the festival stretches throughout the whole of South Tyrol and beyond."
+      },
+      "frequency": "annual",
+      "name": {
+        "eng": "Südtirol Jazz Festival",
+        "ita": "Südtirol Jazz Festival",
+        "deu": "Südtirol Jazz Festival"
+      },
+      "shortName": {
+        "eng": "Südtirol Jazz Festival"
+      },
+      "url": "https://www.suedtiroljazzfestival.com/"
+    },
+    "relationships": {
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "example:festival"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/eventSeries/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/eventSeries/1/multimediaDescriptions"
+        }
+      },
+      "editions": {
+        "data": [
+          {
+            "type": "events",
+            "id": "1"
+          },
+          {
+            "type": "events",
+            "id": "2"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/eventSeries/1/editions"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/eventSeries/1"
+    }
+  }
+}

--- a/openapi/src/examples/eventSeries.json
+++ b/openapi/src/examples/eventSeries.json
@@ -1,0 +1,87 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/eventSeries?page[number]=2",
+      "prev": "https://example.com/2021-04/eventSeries?page[number]=1",
+      "first": "https://example.com/2021-04/eventSeries?page[number]=1",
+      "last": "https://example.com/2021-04/eventSeries?page[number]=10",
+      "self": "https://example.com/2021-04/eventSeries"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "eventSeries",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "eng": "The Südtirol Jazzfestival Alto Adige was held for the first time in 1982 under the name of “Jazz Summer”..."
+        },
+        "description": {
+          "eng": "The Südtirol Jazzfestival Alto Adige was held for the first time in 1982 under the name of “Jazz Summer”, which went on to become “Jazz & Other”. While in the early years the concerts were played only in Bolzano itself, today the festival stretches throughout the whole of South Tyrol and beyond."
+        },
+        "frequency": "annual",
+        "name": {
+          "eng": "Südtirol Jazz Festival",
+          "ita": "Südtirol Jazz Festival",
+          "deu": "Südtirol Jazz Festival"
+        },
+        "shortName": {
+          "eng": "Südtirol Jazz Festival"
+        },
+        "url": "https://www.suedtiroljazzfestival.com/"
+      },
+      "relationships": {
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example:festival"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/eventSeries/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/eventSeries/1/multimediaDescriptions"
+          }
+        },
+        "editions": {
+          "data": [
+            {
+              "type": "events",
+              "id": "1"
+            },
+            {
+              "type": "events",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/eventSeries/1/editions"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/eventSeries/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/eventSeries.multimediaDescriptions.json
+++ b/openapi/src/examples/eventSeries.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/eventSeries/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/events.categories.json
+++ b/openapi/src/examples/events.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:category",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "events" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:category",
+        "resources": {
+          "events": "https://example.com/2021-04/events?filter[categories][any]=example:category"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/events.contributors.json
+++ b/openapi/src/examples/events.contributors.json
@@ -1,0 +1,161 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1/contributors"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "agents",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee...",
+          "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas...",
+          "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions..."
+        },
+        "contactPoints": [
+          {
+            "email": "info@noi.bz.it",
+            "telephone": "+39 0471 066 600",
+            "address": {
+              "street": {
+                "ita": "Piazza Università 1"
+              },
+              "city": {
+                "ita": "Bolzano"
+              },
+              "region": {
+                "ita": "Trentino-Alto Adige"
+              },
+              "country": "IT",
+              "zipcode": "39100",
+              "complement": {
+                "ita": "Ufficio 3.07"
+              },
+              "categories": [
+                "example:main"
+              ]
+            },
+            "availableHours": {
+              "dailySchedules": {
+                "2020-12-23": [
+                  {
+                    "opens": "08:00:00",
+                    "closes": "12:00:00"
+                  }
+                ],
+                "2020-12-25": null
+              },
+              "weeklySchedules": [
+                {
+                  "validFrom": "2020-01-01",
+                  "validTo": "2020-12-31",
+                  "monday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "tuesday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "wednesday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "thursday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "friday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "saturday": null,
+                  "sunday": null
+                }
+              ]
+            }
+          }
+        ],
+        "description": {
+          "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee, al crocevia tra il mondo economico e culturale tedesco e italiano.",
+          "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas an der Schnittstelle zwischen dem deutschsprachigen und italienischen Kultur- und Wirtschaftsraum.",
+          "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions, at the crossroads between the German-speaking and Italian economies and cultures."
+        },
+        "name": {
+          "ita": "Libera Univeristà di Bolzano",
+          "deu": "Freie Universität Bozen",
+          "eng": "Free University of Bozen-Bolzano"
+        },
+        "shortName": {
+          "eng": "Unibz"
+        },
+        "url": "https://www.unibz.it"
+      },
+      "relationships": {
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:organization"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/agents/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/agents/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/events.id.json
+++ b/openapi/src/examples/events.id.json
@@ -1,0 +1,150 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1"
+  },
+  "included": null,
+  "data": {
+    "type": "events",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "name": {
+        "eng": "Südtirol Jazz Festival 2020",
+        "deu": "Südtirol Jazz Festival 2020",
+        "ita": "Südtirol Jazz Festival 2020"
+      },
+      "shortName": {
+        "eng": "Südtirol Jazz Festival 2020"
+      },
+      "description": {
+        "deu": "Beim Südtirol Jazzfestival Alto Adige wagen sich Solisten und Ensembles nicht nur in schwindelerregende musikalische „Höhen“ vor, sondern besteigen, mit ihren Instrumenten im Gepäck, sogar „echte“ Berge und bespielen dabei eine atemberaubende alpine Landschaft. Das Festival selbst beschreitet oft ganz neue Wege: selbstbewusst und sich mitunter über zerklüftete Spalten herantastend, versucht es in neue Klanglandschaften vorzudringen. Mainstream und Konzertsäle sind beim Südtirol Jazzfestival Alto Adige vom Aussterben bedroht...."
+      },
+      "abstract": {
+        "deu": "Das Südtirol Jazzfestival Alto Adige ist ein in Südtirol stattfindendes Musikfestival für Jazz und experimentelle Musik."
+      },
+      "startDate": "2020-06-26T21:00:00+00:00",
+      "endDate": "2020-07-07T23:30:00+00:00",
+      "url": "https://www.suedtiroljazzfestival.com/",
+      "status": "published",
+      "capacity": 1000
+    },
+    "relationships": {
+      "series": {
+        "data": {
+          "type": "eventSeries",
+          "id": "1"
+        },
+        "links": {
+          "related": "https://example.com/2021-04/events/1/eventSeries"
+        }
+      },
+      "publisher": {
+        "data": {
+          "type": "agents",
+          "id": "1"
+        },
+        "links": {
+          "related": "https://example.com/2021-04/events/1/publisher"
+        }
+      },
+      "organizers": {
+        "data": [
+          {
+            "type": "agents",
+            "id": "2"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/events/1/organizers"
+        }
+      },
+      "sponsors": {
+        "data": [
+          {
+            "type": "agents",
+            "id": "3"
+          },
+          {
+            "type": "agents",
+            "id": "4"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/events/1/sponsors"
+        }
+      },
+      "contributors": {
+        "data": [
+          {
+            "type": "agents",
+            "id": "5"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/events/1/contributors"
+        }
+      },
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "schema:MusicEvent"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/events/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          },
+          {
+            "type": "mediaObjects",
+            "id": "2"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/events/1/multimediaDescriptions"
+        }
+      },
+      "venues": {
+        "data": [
+          {
+            "type": "venues",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/events/1/venues"
+        }
+      },
+      "subEvents": {
+        "data": [
+          {
+            "type": "events",
+            "id": "2"
+          },
+          {
+            "type": "events",
+            "id": "3"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/events/1/subEvents"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/events/1"
+    }
+  }
+}

--- a/openapi/src/examples/events.json
+++ b/openapi/src/examples/events.json
@@ -1,0 +1,160 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/events?page[number]=2",
+      "prev": "https://example.com/2021-04/events?page[number]=1",
+      "first": "https://example.com/2021-04/events?page[number]=1",
+      "last": "https://example.com/2021-04/events?page[number]=10",
+      "self": "https://example.com/2021-04/events"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "events",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "eng": "Südtirol Jazz Festival 2020",
+          "deu": "Südtirol Jazz Festival 2020",
+          "ita": "Südtirol Jazz Festival 2020"
+        },
+        "shortName": {
+          "eng": "Südtirol Jazz Festival 2020"
+        },
+        "description": {
+          "deu": "Beim Südtirol Jazzfestival Alto Adige wagen sich Solisten und Ensembles nicht nur in schwindelerregende musikalische „Höhen“ vor, sondern besteigen, mit ihren Instrumenten im Gepäck, sogar „echte“ Berge und bespielen dabei eine atemberaubende alpine Landschaft. Das Festival selbst beschreitet oft ganz neue Wege: selbstbewusst und sich mitunter über zerklüftete Spalten herantastend, versucht es in neue Klanglandschaften vorzudringen. Mainstream und Konzertsäle sind beim Südtirol Jazzfestival Alto Adige vom Aussterben bedroht...."
+        },
+        "abstract": {
+          "deu": "Das Südtirol Jazzfestival Alto Adige ist ein in Südtirol stattfindendes Musikfestival für Jazz und experimentelle Musik."
+        },
+        "startDate": "2020-06-26T21:00:00+00:00",
+        "endDate": "2020-07-07T23:30:00+00:00",
+        "url": "https://www.suedtiroljazzfestival.com/",
+        "status": "published",
+        "capacity": 1000
+      },
+      "relationships": {
+        "series": {
+          "data": {
+            "type": "eventSeries",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/events/1/eventSeries"
+          }
+        },
+        "publisher": {
+          "data": {
+            "type": "agents",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/events/1/publisher"
+          }
+        },
+        "organizers": {
+          "data": [
+            {
+              "type": "agents",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/organizers"
+          }
+        },
+        "sponsors": {
+          "data": [
+            {
+              "type": "agents",
+              "id": "3"
+            },
+            {
+              "type": "agents",
+              "id": "4"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/sponsors"
+          }
+        },
+        "contributors": {
+          "data": [
+            {
+              "type": "agents",
+              "id": "5"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/contributors"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "schema:MusicEvent"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            },
+            {
+              "type": "mediaObjects",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/multimediaDescriptions"
+          }
+        },
+        "venues": {
+          "data": [
+            {
+              "type": "venues",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/venues"
+          }
+        },
+        "subEvents": {
+          "data": [
+            {
+              "type": "events",
+              "id": "2"
+            },
+            {
+              "type": "events",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/1/subEvents"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/events/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/events.multimediaDescriptions.json
+++ b/openapi/src/examples/events.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/events.organizers.json
+++ b/openapi/src/examples/events.organizers.json
@@ -1,0 +1,161 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1/organizers"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "agents",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee...",
+          "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas...",
+          "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions..."
+        },
+        "contactPoints": [
+          {
+            "email": "info@noi.bz.it",
+            "telephone": "+39 0471 066 600",
+            "address": {
+              "street": {
+                "ita": "Piazza Università 1"
+              },
+              "city": {
+                "ita": "Bolzano"
+              },
+              "region": {
+                "ita": "Trentino-Alto Adige"
+              },
+              "country": "IT",
+              "zipcode": "39100",
+              "complement": {
+                "ita": "Ufficio 3.07"
+              },
+              "categories": [
+                "example:main"
+              ]
+            },
+            "availableHours": {
+              "dailySchedules": {
+                "2020-12-23": [
+                  {
+                    "opens": "08:00:00",
+                    "closes": "12:00:00"
+                  }
+                ],
+                "2020-12-25": null
+              },
+              "weeklySchedules": [
+                {
+                  "validFrom": "2020-01-01",
+                  "validTo": "2020-12-31",
+                  "monday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "tuesday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "wednesday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "thursday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "friday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "saturday": null,
+                  "sunday": null
+                }
+              ]
+            }
+          }
+        ],
+        "description": {
+          "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee, al crocevia tra il mondo economico e culturale tedesco e italiano.",
+          "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas an der Schnittstelle zwischen dem deutschsprachigen und italienischen Kultur- und Wirtschaftsraum.",
+          "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions, at the crossroads between the German-speaking and Italian economies and cultures."
+        },
+        "name": {
+          "ita": "Libera Univeristà di Bolzano",
+          "deu": "Freie Universität Bozen",
+          "eng": "Free University of Bozen-Bolzano"
+        },
+        "shortName": {
+          "eng": "Unibz"
+        },
+        "url": "https://www.unibz.it"
+      },
+      "relationships": {
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:organization"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/agents/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/agents/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/events.publisher.json
+++ b/openapi/src/examples/events.publisher.json
@@ -1,0 +1,159 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1/publisher"
+  },
+  "included": null,
+  "data": {
+    "type": "agents",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee...",
+        "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas...",
+        "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions..."
+      },
+      "contactPoints": [
+        {
+          "email": "info@noi.bz.it",
+          "telephone": "+39 0471 066 600",
+          "address": {
+            "street": {
+              "ita": "Piazza Università 1"
+            },
+            "city": {
+              "ita": "Bolzano"
+            },
+            "region": {
+              "ita": "Trentino-Alto Adige"
+            },
+            "country": "IT",
+            "zipcode": "39100",
+            "complement": {
+              "ita": "Ufficio 3.07"
+            },
+            "categories": [
+              "example:main"
+            ]
+          },
+          "availableHours": {
+            "dailySchedules": {
+              "2020-12-23": [
+                {
+                  "opens": "08:00:00",
+                  "closes": "12:00:00"
+                }
+              ],
+              "2020-12-25": null
+            },
+            "weeklySchedules": [
+              {
+                "validFrom": "2020-01-01",
+                "validTo": "2020-12-31",
+                "monday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "tuesday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "wednesday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "thursday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "friday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "saturday": null,
+                "sunday": null
+              }
+            ]
+          }
+        }
+      ],
+      "description": {
+        "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee, al crocevia tra il mondo economico e culturale tedesco e italiano.",
+        "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas an der Schnittstelle zwischen dem deutschsprachigen und italienischen Kultur- und Wirtschaftsraum.",
+        "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions, at the crossroads between the German-speaking and Italian economies and cultures."
+      },
+      "name": {
+        "ita": "Libera Univeristà di Bolzano",
+        "deu": "Freie Universität Bozen",
+        "eng": "Free University of Bozen-Bolzano"
+      },
+      "shortName": {
+        "eng": "Unibz"
+      },
+      "url": "https://www.unibz.it"
+    },
+    "relationships": {
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "alpinebits:organization"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/agents/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/agents/1"
+    }
+  }
+}

--- a/openapi/src/examples/events.series.json
+++ b/openapi/src/examples/events.series.json
@@ -1,0 +1,77 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/eventSeries/1"
+  },
+  "included": null,
+  "data": {
+    "type": "eventSeries",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "eng": "The Südtirol Jazzfestival Alto Adige was held for the first time in 1982 under the name of “Jazz Summer”..."
+      },
+      "description": {
+        "eng": "The Südtirol Jazzfestival Alto Adige was held for the first time in 1982 under the name of “Jazz Summer”, which went on to become “Jazz & Other”. While in the early years the concerts were played only in Bolzano itself, today the festival stretches throughout the whole of South Tyrol and beyond."
+      },
+      "frequency": "annual",
+      "name": {
+        "eng": "Südtirol Jazz Festival",
+        "ita": "Südtirol Jazz Festival",
+        "deu": "Südtirol Jazz Festival"
+      },
+      "shortName": {
+        "eng": "Südtirol Jazz Festival"
+      },
+      "url": "https://www.suedtiroljazzfestival.com/"
+    },
+    "relationships": {
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "example:festival"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/eventSeries/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/eventSeries/1/multimediaDescriptions"
+        }
+      },
+      "editions": {
+        "data": [
+          {
+            "type": "events",
+            "id": "1"
+          },
+          {
+            "type": "events",
+            "id": "2"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/eventSeries/1/editions"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/eventSeries/1"
+    }
+  }
+}

--- a/openapi/src/examples/events.sponsors.json
+++ b/openapi/src/examples/events.sponsors.json
@@ -1,0 +1,161 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1/sponsors"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "agents",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee...",
+          "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas...",
+          "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions..."
+        },
+        "contactPoints": [
+          {
+            "email": "info@noi.bz.it",
+            "telephone": "+39 0471 066 600",
+            "address": {
+              "street": {
+                "ita": "Piazza Università 1"
+              },
+              "city": {
+                "ita": "Bolzano"
+              },
+              "region": {
+                "ita": "Trentino-Alto Adige"
+              },
+              "country": "IT",
+              "zipcode": "39100",
+              "complement": {
+                "ita": "Ufficio 3.07"
+              },
+              "categories": [
+                "example:main"
+              ]
+            },
+            "availableHours": {
+              "dailySchedules": {
+                "2020-12-23": [
+                  {
+                    "opens": "08:00:00",
+                    "closes": "12:00:00"
+                  }
+                ],
+                "2020-12-25": null
+              },
+              "weeklySchedules": [
+                {
+                  "validFrom": "2020-01-01",
+                  "validTo": "2020-12-31",
+                  "monday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "tuesday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "wednesday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "thursday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "friday": [
+                    {
+                      "opens": "08:00:00+01:00",
+                      "closes": "12:00:00+01:00"
+                    },
+                    {
+                      "opens": "14:00:00+01:00",
+                      "closes": "18:00:00+01:00"
+                    }
+                  ],
+                  "saturday": null,
+                  "sunday": null
+                }
+              ]
+            }
+          }
+        ],
+        "description": {
+          "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee, al crocevia tra il mondo economico e culturale tedesco e italiano.",
+          "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas an der Schnittstelle zwischen dem deutschsprachigen und italienischen Kultur- und Wirtschaftsraum.",
+          "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions, at the crossroads between the German-speaking and Italian economies and cultures."
+        },
+        "name": {
+          "ita": "Libera Univeristà di Bolzano",
+          "deu": "Freie Universität Bozen",
+          "eng": "Free University of Bozen-Bolzano"
+        },
+        "shortName": {
+          "eng": "Unibz"
+        },
+        "url": "https://www.unibz.it"
+      },
+      "relationships": {
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:organization"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/agents/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/agents/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/events.subEvents.json
+++ b/openapi/src/examples/events.subEvents.json
@@ -1,0 +1,74 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1/subEvents"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "events",
+      "id": "2",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "name": {
+          "eng": "Südtirol Jazz Festival 2018"
+        },
+        "shortName": null,
+        "description": null,
+        "abstract": null,
+        "startDate": "2018-06-29T00:00:00+00:00",
+        "endDate": null,
+        "url": null,
+        "status": null,
+        "capacity": null
+      },
+      "relationships": {
+        "series": null,
+        "publisher": {
+          "data": {
+            "type": "agents",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/events/2/publisher"
+          }
+        },
+        "organizers": {
+          "data": [
+            {
+              "type": "agents",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/2/organizers"
+          }
+        },
+        "sponsors": null,
+        "contributors": null,
+        "categories": null,
+        "multimediaDescriptions": null,
+        "venues": {
+          "data": [
+            {
+              "type": "venues",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/events/2/venues"
+          }
+        },
+        "subEvents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/events/2"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/events.venues.json
+++ b/openapi/src/examples/events.venues.json
@@ -1,0 +1,94 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/events/1/venues"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "venues",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "eng": "The Auditorium 1 of the Free University of Bozen-Bolzano provides a great space for keynotes, lectures and presentations."
+        },
+        "address": {
+          "street": {
+            "ita": "Piazza Università, 1",
+            "deu": "Universitätsplatz 1"
+          },
+          "city": {
+            "deu": "Bozen"
+          },
+          "region": {
+            "deu": "Trentino-Südtirol"
+          },
+          "country": "IT",
+          "zipcode": "39100",
+          "complement": {
+            "deu": "Hauptgebäude"
+          },
+          "categories": [
+            "example/building"
+          ]
+        },
+        "area": 150,
+        "description": {
+          "eng": "The Auditorium 1 of the Free University of Bozen-Bolzano provides a great space for keynotes, lectures and presentations, being available to host events related academic, provincial and cultural topics."
+        },
+        "geometries": [
+          {
+            "type": "Point",
+            "coordinates": [
+              11.35087251663208,
+              46.49873937419277
+            ]
+          }
+        ],
+        "howToArrive": {
+          "eng": "From the train station, the Free University of Bozen-Bolzano is accessible in a 5 minutes walk into the historical city center."
+        },
+        "name": {
+          "eng": "Auditorium 1 - Free University of Bozen-Bolzano"
+        },
+        "shortName": {
+          "eng": "Auditorium 1"
+        },
+        "url": "https://example.com/auditorium-1"
+      },
+      "relationships": {
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example:auditorium"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/venues/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/venues/1/multimediaDescriptions"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/venues/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/features.children.json
+++ b/openapi/src/examples/features.children.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/features/example:feature/children"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "features",
+      "id": "example:subfeature",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Child Feature"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "events" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/features/example:subfeature",
+        "resources": {
+          "events": "https://example.com/2021-04/events?filter[features][any]=example:subfeature"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/features.id.json
+++ b/openapi/src/examples/features.id.json
@@ -1,0 +1,81 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/features/example:snowparkRamp"
+  },
+  "included": null,
+  "data": {
+    "type": "features",
+    "id": "example:snowparkRamp",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2021-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "ita": "Una rampa di snowpark è una struttura per la pratica di manovre aeree negli sport invernali radicali.",
+        "deu": "Eine Snowpark-Rampe ist eine Struktur zum Üben von Flugmanövern im radikalen Wintersport.",
+        "eng": "A snowpark ramp is a structure for the practice of aerial maneuvers in radical winter sports."
+      },
+      "description": {
+        "ita": "Una rampa da snowpark è una struttura presente negli snowpark progettata per supportare l'esecuzione di manovre aeree negli sport invernali radicali.",
+        "deu": "Eine Snowpark-Rampe ist eine Einrichtung in Snowparks, die dazu dient, die Ausführung von Flugmanövern bei radikalen Wintersportarten zu unterstützen.",
+        "eng": "A snowpark ramp is a feature present in snowparks designed to support the execution of aerial maneuvers in radical winter sports."
+      },
+      "name": {
+        "ita": "Snowpark Ramp",
+        "deu": "Snowpark Rampe",
+        "eng": "Snowpark Ramp"
+      },
+      "namespace": "example",
+      "resourceTypes": [ "snowparks" ],
+      "shortName": {
+        "eng": "Snowpark Ramp"
+      },
+      "url": "https://en.wikipedia.org/wiki/Terrain_park"
+    },
+    "relationships": {
+      "children": {
+        "data": [
+          {
+            "type": "features",
+            "id": "example:snowboardRamp"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/features/example:snowparkRamp/children"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/features/example:snowparkRamp/multimediaDescriptions"
+        }
+      },
+      "parents": {
+        "data": [
+          {
+            "type": "features",
+            "id": "example:radicalSportsRamp"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/features/example:snowparkRamp/parents"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/features/example:snowparkRamp",
+      "resources": {
+        "snowparks": "https://example.com/2021-04/snowparks?filter[features][any]=example:snowparkRamp"
+      }
+    }
+  }
+}

--- a/openapi/src/examples/features.json
+++ b/openapi/src/examples/features.json
@@ -1,0 +1,91 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/features?page[number]=2",
+      "prev": "https://example.com/2021-04/features?page[number]=1",
+      "first": "https://example.com/2021-04/features?page[number]=1",
+      "last": "https://example.com/2021-04/features?page[number]=10",
+      "self": "https://example.com/2021-04/features"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "features",
+      "id": "example:snowparkRamp",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2021-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "ita": "Una rampa di snowpark è una struttura per la pratica di manovre aeree negli sport invernali radicali.",
+          "deu": "Eine Snowpark-Rampe ist eine Struktur zum Üben von Flugmanövern im radikalen Wintersport.",
+          "eng": "A snowpark ramp is a structure for the practice of aerial maneuvers in radical winter sports."
+        },
+        "description": {
+          "ita": "Una rampa da snowpark è una struttura presente negli snowpark progettata per supportare l'esecuzione di manovre aeree negli sport invernali radicali.",
+          "deu": "Eine Snowpark-Rampe ist eine Einrichtung in Snowparks, die dazu dient, die Ausführung von Flugmanövern bei radikalen Wintersportarten zu unterstützen.",
+          "eng": "A snowpark ramp is a feature present in snowparks designed to support the execution of aerial maneuvers in radical winter sports."
+        },
+        "name": {
+          "ita": "Snowpark Ramp",
+          "deu": "Snowpark Rampe",
+          "eng": "Snowpark Ramp"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "snowparks" ],
+        "shortName": {
+          "eng": "Snowpark Ramp"
+        },
+        "url": "https://en.wikipedia.org/wiki/Terrain_park"
+      },
+      "relationships": {
+        "children": {
+          "data": [
+            {
+              "type": "features",
+              "id": "example:snowboardRamp"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/features/example:snowparkRamp/children"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/features/example:snowparkRamp/multimediaDescriptions"
+          }
+        },
+        "parents": {
+          "data": [
+            {
+              "type": "features",
+              "id": "example:radicalSportsRamp"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/features/example:snowparkRamp/parents"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/features/example:snowparkRamp",
+        "resources": {
+          "snowparks": "https://example.com/2021-04/snowparks?filter[features][any]=example:snowparkRamp"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/features.multimediaDescriptions.json
+++ b/openapi/src/examples/features.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/features/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/features.parents.json
+++ b/openapi/src/examples/features.parents.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/features/example:feature/parents"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "features",
+      "id": "example:superfeature",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Parent Feature"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "events" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/features/example:superfeature",
+        "resources": {
+          "events": "https://example.com/2021-04/events?filter[features][any]=example:superfeature"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/lifts.categories.json
+++ b/openapi/src/examples/lifts.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/lifts/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:category",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "lifts" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:category",
+        "resources": {
+          "lifts": "https://example.com/2021-04/lifts?filter[categories][any]=example:category"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/lifts.connections.json
+++ b/openapi/src/examples/lifts.connections.json
@@ -1,0 +1,250 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/lifts/1/connections"
+  },
+  "included": null,
+  "data": [
+    {
+      "id": "1",
+      "type": "mountainAreas",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Merano 2000",
+          "deu": "Meran 2000",
+          "eng": "Meran 2000"
+        },
+        "shortName": {
+          "eng": "Meran 2000"
+        },
+        "description": {
+          "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe. Von Meran aus ist das Gebiet direkt über die Ifinger-Seilbahn ab Naif oder durch eine Umlaufseilbahn ab Falzeben erreichbar. Das Skigebiet erstreckt sich hauptsächlich auf dem Gemeindegebiet von Hafling, berührt aber auch zu den Gemeinden Schenna und Sarntal gehörende Flächen."
+        },
+        "abstract": {
+          "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe."
+        },
+        "url": "https://www.meran2000.com",
+        "geometries": [
+          {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  11.310853958129883,
+                  46.66958283253642
+                ],
+                [
+                  11.304588317871094,
+                  46.668817160723044
+                ],
+                [
+                  11.301412582397461,
+                  46.666696782172096
+                ],
+                [
+                  11.305532455444336,
+                  46.66457632044435
+                ],
+                [
+                  11.31265640258789,
+                  46.66646117942096
+                ],
+                [
+                  11.314373016357422,
+                  46.66869936409677
+                ],
+                [
+                  11.310853958129883,
+                  46.66958283253642
+                ]
+              ]
+            ]
+          }
+        ],
+        "howToArrive": {
+          "ita": "L'area sciistica ed escursionistica di Merano è situata ai piedi della montagna Picco Ivigna ed è raggiungibile in pochi minuti dalle destinazioni di Merano, Avelengo, Scena e Tirolo. La cima di Merano 2000 è raggiungibile con due impianti di risalita diversi e ha dunque due stazioni a valle, una presso Merano con la Funivia e una ad Avelengo con la Cabinovia Falzeben.",
+          "deu": "Die Sonnenterrasse Merans liegt am Fuße des Ifingers und ist von den Ferienorten Meran, Hafling, Schenna und Dorf Tirol in wenigen Minuten leicht erreichbar. Die Bergstation von Meran 2000 kann man mit zwei verschiedenen Aufstiegsanlagen erreichen: von Meran aus mit der Bergbahn und von Hafling aus mit der Umlaufbahn Falzeben.",
+          "eng": "The skiing and hiking area of Merano 2000 is best located next to the biggest vacation hotspots of South Tyrol and so reachable within few minutes from Merano, Avelengo, Scena and Tirolo. Two lifts can bring you to the mountain station of Merano 2000: the Ropeway in Merano or the Gondola Falzeben in Avelengo."
+        },
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "area": 36000,
+        "minAltitude": 1200,
+        "maxAltitude": 2000,
+        "totalTrailLength": 4000,
+        "totalParkArea": 20000,
+        "totalParkLength": 1000,
+        "snowCondition": {
+          "primarySurface": "powder",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 50,
+          "baseSnowRange": {
+            "lower": 40,
+            "upper": 60
+          },
+          "latestStorm": 40,
+          "obtainedIn": "2019-12-20",
+          "snowOverNight": 5,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "areaOwner": {
+          "data": {
+            "type": "agents",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/areaOwner/"
+          }
+        },
+        "connections": {
+          "data": [
+            {
+              "type": "lifts",
+              "id": "1"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example/skiarea"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/multimediaDescriptions/"
+          }
+        },
+        "lifts": {
+          "data": [
+            {
+              "type": "lifts",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/lifts/"
+          }
+        },
+        "skiSlopes": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/skiSlopes/"
+          }
+        },
+        "snowparks": {
+          "data": [
+            {
+              "type": "snowparks",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/snowparks/"
+          }
+        },
+        "subAreas": {
+          "data": [
+            {
+              "type": "mountainAreas",
+              "id": "2"
+            },
+            {
+              "type": "mountainAreas",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/subAreas/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mountainAreas/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/lifts.id.json
+++ b/openapi/src/examples/lifts.id.json
@@ -1,0 +1,180 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/lifts/1"
+  },
+  "included": null,
+  "data": {
+    "type": "lifts",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "name": {
+        "deu": "Bergbahn Meran 2000",
+        "eng": "Ropeway Merano 2000",
+        "ita": "Funivia Merano 2000"
+      },
+      "shortName": {
+        "deu": "Meran 2000",
+        "eng": "Merano 2000",
+        "ita": "Merano 2000"
+      },
+      "description": {
+        "ita": "Situata a pochi minuti dalla città di Merano, la Funivia conduce all’area sciistica ed escursionistica Merano 2000, un luogo ideale in cui passare una vacanza all’insegna del movimento e della buona cucina con tutta la famiglia. Grazie al suo clima mite, l’area offre infinite possibilità per il tempo libero in ogni stagione: impianti di risalita, sentieri escursionistici facili e numerosi rifugi in cui sostare per assaporare l’ottima cucina locale in un paesaggio ricco e dominato dalla tranquillità."
+      },
+      "abstract": {
+        "ita": "Situata a pochi minuti dalla città di Merano, la Funivia conduce all’area sciistica ed escursionistica Merano 2000, un luogo ideale in cui passare una vacanza all’insegna del movimento e della buona cucina con tutta la famiglia..."
+      },
+      "url": "https://example.com",
+      "length": 3650,
+      "minAltitude": 1000,
+      "maxAltitude": 2350,
+      "capacity": 200,
+      "personsPerChair": 10,
+      "openingHours": {
+        "dailySchedules": {
+          "2020-12-25": null
+        },
+        "weeklySchedules": [
+          {
+            "validFrom": "2020-01-01",
+            "validTo": "2020-12-31",
+            "monday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "tuesday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "wednesday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "thursday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "friday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "saturday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "sunday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ]
+          }
+        ]
+      },
+      "address": {
+        "street": {
+          "deu": "Naifweg 37",
+          "eng": "37 Val di Nova Street",
+          "ita": "Via Val di Nova, 37"
+        },
+        "city": {
+          "deu": "Meran",
+          "eng": "Merano",
+          "ita": "Merano"
+        },
+        "region": {
+          "deu": "Trentino-Südtirol",
+          "eng": "Trentino-Alto Adige",
+          "ita": "Trentino-Alto Adige"
+        },
+        "country": "IT",
+        "zipcode": "39012",
+        "categories": null,
+        "complement": null
+      },
+      "geometries": [
+        {
+          "type": "LineString",
+          "coordinates": [
+            [
+              11.305682659149168,
+              46.66705018437341
+            ],
+            [
+              11.30692720413208,
+              46.667182709603225
+            ],
+            [
+              11.308064460754393,
+              46.667491933875965
+            ]
+          ]
+        }
+      ],
+      "howToArrive": {
+        "ita": "Fino alla stazione a valle della Funivia Merano 2000: dalla stazione ferroviaria di Merano si raggiunge in pochi minuti la stazione a valle Val di Nova con la linea urbana 1A. Da Scena c'è il bus vacanze che porta fino alla Val di Nova.",
+        "deu": "Zur Talstation der Bergbahn Meran 2000: vom Zugbahnhof Meran erreicht man in wenigen Minuten die Talstation Naif mit der Buslinie 1A. Von Schenna aus fährt der Gästebus bis zur Talstation Naif."
+      }
+    },
+    "relationships": {
+      "connections": {
+        "data": [
+          {
+            "type": "skiSlopes",
+            "id": "1"
+          },
+          {
+            "type": "skiSlopes",
+            "id": "2"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/lifts/1/connections/"
+        }
+      },
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "alpinebits:cablecar"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/lifts/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/lifts/1/multimediaDescriptions/"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/lifts/1"
+    }
+  }
+}

--- a/openapi/src/examples/lifts.json
+++ b/openapi/src/examples/lifts.json
@@ -1,0 +1,190 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/lifts?page[number]=2",
+      "prev": "https://example.com/2021-04/lifts?page[number]=1",
+      "first": "https://example.com/2021-04/lifts?page[number]=1",
+      "last": "https://example.com/2021-04/lifts?page[number]=10",
+      "self": "https://example.com/2021-04/lifts"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "lifts",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "deu": "Bergbahn Meran 2000",
+          "eng": "Ropeway Merano 2000",
+          "ita": "Funivia Merano 2000"
+        },
+        "shortName": {
+          "deu": "Meran 2000",
+          "eng": "Merano 2000",
+          "ita": "Merano 2000"
+        },
+        "description": {
+          "ita": "Situata a pochi minuti dalla città di Merano, la Funivia conduce all’area sciistica ed escursionistica Merano 2000, un luogo ideale in cui passare una vacanza all’insegna del movimento e della buona cucina con tutta la famiglia. Grazie al suo clima mite, l’area offre infinite possibilità per il tempo libero in ogni stagione: impianti di risalita, sentieri escursionistici facili e numerosi rifugi in cui sostare per assaporare l’ottima cucina locale in un paesaggio ricco e dominato dalla tranquillità."
+        },
+        "abstract": {
+          "ita": "Situata a pochi minuti dalla città di Merano, la Funivia conduce all’area sciistica ed escursionistica Merano 2000, un luogo ideale in cui passare una vacanza all’insegna del movimento e della buona cucina con tutta la famiglia..."
+        },
+        "url": "https://example.com",
+        "length": 3650,
+        "minAltitude": 1000,
+        "maxAltitude": 2350,
+        "capacity": 200,
+        "personsPerChair": 10,
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "address": {
+          "street": {
+            "deu": "Naifweg 37",
+            "eng": "37 Val di Nova Street",
+            "ita": "Via Val di Nova, 37"
+          },
+          "city": {
+            "deu": "Meran",
+            "eng": "Merano",
+            "ita": "Merano"
+          },
+          "region": {
+            "deu": "Trentino-Südtirol",
+            "eng": "Trentino-Alto Adige",
+            "ita": "Trentino-Alto Adige"
+          },
+          "country": "IT",
+          "zipcode": "39012",
+          "categories": null,
+          "complement": null
+        },
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "howToArrive": {
+          "ita": "Fino alla stazione a valle della Funivia Merano 2000: dalla stazione ferroviaria di Merano si raggiunge in pochi minuti la stazione a valle Val di Nova con la linea urbana 1A. Da Scena c'è il bus vacanze che porta fino alla Val di Nova.",
+          "deu": "Zur Talstation der Bergbahn Meran 2000: vom Zugbahnhof Meran erreicht man in wenigen Minuten die Talstation Naif mit der Buslinie 1A. Von Schenna aus fährt der Gästebus bis zur Talstation Naif."
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:cablecar"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/lifts/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/lifts.multimediaDescriptions.json
+++ b/openapi/src/examples/lifts.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/lifts/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mediaObjects.categories.json
+++ b/openapi/src/examples/mediaObjects.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mediaObjects/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:category",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "mediaObjects" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:category",
+        "resources": {
+          "mediaObjects": "https://example.com/2021-04/mediaObjects?filter[categories][any]=example:category"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mediaObjects.copyrightOwner.json
+++ b/openapi/src/examples/mediaObjects.copyrightOwner.json
@@ -1,0 +1,159 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mediaObjects/1/copyrightOwner"
+  },
+  "included": null,
+  "data": {
+    "type": "agents",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee...",
+        "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas...",
+        "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions..."
+      },
+      "contactPoints": [
+        {
+          "email": "info@noi.bz.it",
+          "telephone": "+39 0471 066 600",
+          "address": {
+            "street": {
+              "ita": "Piazza Università 1"
+            },
+            "city": {
+              "ita": "Bolzano"
+            },
+            "region": {
+              "ita": "Trentino-Alto Adige"
+            },
+            "country": "IT",
+            "zipcode": "39100",
+            "complement": {
+              "ita": "Ufficio 3.07"
+            },
+            "categories": [
+              "example:main"
+            ]
+          },
+          "availableHours": {
+            "dailySchedules": {
+              "2020-12-23": [
+                {
+                  "opens": "08:00:00",
+                  "closes": "12:00:00"
+                }
+              ],
+              "2020-12-25": null
+            },
+            "weeklySchedules": [
+              {
+                "validFrom": "2020-01-01",
+                "validTo": "2020-12-31",
+                "monday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "tuesday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "wednesday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "thursday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "friday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "saturday": null,
+                "sunday": null
+              }
+            ]
+          }
+        }
+      ],
+      "description": {
+        "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee, al crocevia tra il mondo economico e culturale tedesco e italiano.",
+        "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas an der Schnittstelle zwischen dem deutschsprachigen und italienischen Kultur- und Wirtschaftsraum.",
+        "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions, at the crossroads between the German-speaking and Italian economies and cultures."
+      },
+      "name": {
+        "ita": "Libera Univeristà di Bolzano",
+        "deu": "Freie Universität Bozen",
+        "eng": "Free University of Bozen-Bolzano"
+      },
+      "shortName": {
+        "eng": "Unibz"
+      },
+      "url": "https://www.unibz.it"
+    },
+    "relationships": {
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "alpinebits:organization"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/agents/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/agents/1"
+    }
+  }
+}

--- a/openapi/src/examples/mediaObjects.id.json
+++ b/openapi/src/examples/mediaObjects.id.json
@@ -1,0 +1,64 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mediaObjects/1"
+  },
+  "included": null,
+  "data": {
+    "type": "mediaObjects",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "eng": "My first image sent as an example for the API."
+      },
+      "contentType": "image/png",
+      "description": {
+        "eng": "My first image sent as an example for the API."
+      },
+      "duration": null,
+      "height": 300,
+      "license": "FreeImage",
+      "name": {
+        "ita": "La mia immagine",
+        "deu": "Mein bild",
+        "eng": "My image"
+      },
+      "shortName": {
+        "eng": "My image"
+      },
+      "url": "https://example.com/image.png",
+      "width": 400
+    },
+    "relationships": {
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "example/panoramic-photo"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/mediaObjects/1/categories"
+        }
+      },
+      "copyrightOwner": {
+        "data": {
+          "type": "agents",
+          "id": "0"
+        },
+        "links": {
+          "related": "https://example.com/2021-04/mediaObjects/1/copyrgihtOwner/"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/mediaObjects/1"
+    }
+  }
+}

--- a/openapi/src/examples/mediaObjects.json
+++ b/openapi/src/examples/mediaObjects.json
@@ -1,0 +1,74 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/mediaObjects?page[number]=2",
+      "prev": "https://example.com/2021-04/mediaObjects?page[number]=1",
+      "first": "https://example.com/2021-04/mediaObjects?page[number]=1",
+      "last": "https://example.com/2021-04/mediaObjects?page[number]=10",
+      "self": "https://example.com/2021-04/mediaObjects"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "eng": "My first image sent as an example for the API."
+        },
+        "contentType": "image/png",
+        "description": {
+          "eng": "My first image sent as an example for the API."
+        },
+        "duration": null,
+        "height": 300,
+        "license": "FreeImage",
+        "name": {
+          "ita": "La mia immagine",
+          "deu": "Mein bild",
+          "eng": "My image"
+        },
+        "shortName": {
+          "eng": "My image"
+        },
+        "url": "https://example.com/image.png",
+        "width": 400
+      },
+      "relationships": {
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example/panoramic-photo"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mediaObjects/1/categories"
+          }
+        },
+        "copyrightOwner": {
+          "data": {
+            "type": "agents",
+            "id": "0"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/mediaObjects/1/copyrgihtOwner/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mountainAreas.areaOwner.json
+++ b/openapi/src/examples/mountainAreas.areaOwner.json
@@ -1,0 +1,159 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1/areaOwner"
+  },
+  "included": null,
+  "data": {
+    "type": "agents",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee...",
+        "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas...",
+        "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions..."
+      },
+      "contactPoints": [
+        {
+          "email": "info@noi.bz.it",
+          "telephone": "+39 0471 066 600",
+          "address": {
+            "street": {
+              "ita": "Piazza Università 1"
+            },
+            "city": {
+              "ita": "Bolzano"
+            },
+            "region": {
+              "ita": "Trentino-Alto Adige"
+            },
+            "country": "IT",
+            "zipcode": "39100",
+            "complement": {
+              "ita": "Ufficio 3.07"
+            },
+            "categories": [
+              "example:main"
+            ]
+          },
+          "availableHours": {
+            "dailySchedules": {
+              "2020-12-23": [
+                {
+                  "opens": "08:00:00",
+                  "closes": "12:00:00"
+                }
+              ],
+              "2020-12-25": null
+            },
+            "weeklySchedules": [
+              {
+                "validFrom": "2020-01-01",
+                "validTo": "2020-12-31",
+                "monday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "tuesday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "wednesday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "thursday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "friday": [
+                  {
+                    "opens": "08:00:00+01:00",
+                    "closes": "12:00:00+01:00"
+                  },
+                  {
+                    "opens": "14:00:00+01:00",
+                    "closes": "18:00:00+01:00"
+                  }
+                ],
+                "saturday": null,
+                "sunday": null
+              }
+            ]
+          }
+        }
+      ],
+      "description": {
+        "ita": "La Libera Università di Bolzano sorge in una delle più attraenti regioni europee, al crocevia tra il mondo economico e culturale tedesco e italiano.",
+        "deu": "Die Freie Universität Bozen befindet sich in einer der attraktivsten Regionen Europas an der Schnittstelle zwischen dem deutschsprachigen und italienischen Kultur- und Wirtschaftsraum.",
+        "eng": "The Free University of Bozen-Bolzano is located in one of the most fascinating European regions, at the crossroads between the German-speaking and Italian economies and cultures."
+      },
+      "name": {
+        "ita": "Libera Univeristà di Bolzano",
+        "deu": "Freie Universität Bozen",
+        "eng": "Free University of Bozen-Bolzano"
+      },
+      "shortName": {
+        "eng": "Unibz"
+      },
+      "url": "https://www.unibz.it"
+    },
+    "relationships": {
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "alpinebits:organization"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/agents/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/agents/1/multimediaDescriptions"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/agents/1"
+    }
+  }
+}

--- a/openapi/src/examples/mountainAreas.categories.json
+++ b/openapi/src/examples/mountainAreas.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:category",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "mountainAreas" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:category",
+        "resources": {
+          "mountainAreas": "https://example.com/2021-04/mountainAreas?filter[categories][any]=example:category"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mountainAreas.connections.json
+++ b/openapi/src/examples/mountainAreas.connections.json
@@ -1,0 +1,548 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1/connections"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "lifts",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "deu": "Bergbahn Meran 2000",
+          "eng": "Ropeway Merano 2000",
+          "ita": "Funivia Merano 2000"
+        },
+        "shortName": {
+          "deu": "Meran 2000",
+          "eng": "Merano 2000",
+          "ita": "Merano 2000"
+        },
+        "description": {
+          "ita": "Situata a pochi minuti dalla città di Merano, la Funivia conduce all’area sciistica ed escursionistica Merano 2000, un luogo ideale in cui passare una vacanza all’insegna del movimento e della buona cucina con tutta la famiglia. Grazie al suo clima mite, l’area offre infinite possibilità per il tempo libero in ogni stagione: impianti di risalita, sentieri escursionistici facili e numerosi rifugi in cui sostare per assaporare l’ottima cucina locale in un paesaggio ricco e dominato dalla tranquillità."
+        },
+        "abstract": {
+          "ita": "Situata a pochi minuti dalla città di Merano, la Funivia conduce all’area sciistica ed escursionistica Merano 2000, un luogo ideale in cui passare una vacanza all’insegna del movimento e della buona cucina con tutta la famiglia..."
+        },
+        "url": "https://example.com",
+        "length": 3650,
+        "minAltitude": 1000,
+        "maxAltitude": 2350,
+        "capacity": 200,
+        "personsPerChair": 10,
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "address": {
+          "street": {
+            "deu": "Naifweg 37",
+            "eng": "37 Val di Nova Street",
+            "ita": "Via Val di Nova, 37"
+          },
+          "city": {
+            "deu": "Meran",
+            "eng": "Merano",
+            "ita": "Merano"
+          },
+          "region": {
+            "deu": "Trentino-Südtirol",
+            "eng": "Trentino-Alto Adige",
+            "ita": "Trentino-Alto Adige"
+          },
+          "country": "IT",
+          "zipcode": "39012",
+          "categories": null,
+          "complement": null
+        },
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "howToArrive": {
+          "ita": "Fino alla stazione a valle della Funivia Merano 2000: dalla stazione ferroviaria di Merano si raggiunge in pochi minuti la stazione a valle Val di Nova con la linea urbana 1A. Da Scena c'è il bus vacanze che porta fino alla Val di Nova.",
+          "deu": "Zur Talstation der Bergbahn Meran 2000: vom Zugbahnhof Meran erreicht man in wenigen Minuten die Talstation Naif mit der Buslinie 1A. Von Schenna aus fährt der Gästebus bis zur Talstation Naif."
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:cablecar"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/lifts/1"
+      }
+    },
+    {
+      "type": "skiSlopes",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Falzeben I",
+          "deu": "Falzeben I",
+          "eng": "Falzeben I"
+        },
+        "shortName": {
+          "ita": "Falzeben I"
+        },
+        "description": {
+          "ita": "Falzeben I -  Discesa tra i boschi facile, immersa in un panorama da sogno ed ideale per bambini e principianti. Altezza/Lunghezza: 1900 altezza, 3500 m."
+        },
+        "abstract": {
+          "ita": "Falzeben I -  Discesa tra i boschi facile, immersa in un panorama da sogno ed ideale per bambini e principianti."
+        },
+        "url": "https://example.com",
+        "length": 2000,
+        "minAltitude": 1500,
+        "maxAltitude": 2500,
+        "difficulty": {
+          "eu": "novice",
+          "us": "beginner"
+        },
+        "address": {
+          "street": null,
+          "city": {
+            "eng": "Merano"
+          },
+          "region": null,
+          "country": "IT",
+          "zipcode": null,
+          "categories": null,
+          "complement": null
+        },
+        "howToArrive": {
+          "ita": " Le fermate più vicine a Falzeben sono: Falzeben è a 41 metri di distanza a piedi e ci si arriva in 1 minuti di cammino; Villa Schäfer è a 808 metri di distanza a piedi e ci si arriva in 11 minuti di cammino."
+        },
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "snowCondition": {
+          "primarySurface": "powder",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 50,
+          "baseSnowRange": {
+            "lower": 40,
+            "upper": 60
+          },
+          "latestStorm": 40,
+          "obtainedIn": "2020-02-01",
+          "snowOverNight": 5,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "3"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "4"
+            },
+            {
+              "type": "lifts",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:standard-ski-slope"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/skiSlopes/1"
+      }
+    },
+    {
+      "type": "snowparks",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Snowpark Merano 2000",
+          "deu": "Snowpark Merano 2000",
+          "eng": "Snowpark Merano 2000"
+        },
+        "shortName": {
+          "eng": "Snowpark Merano 2000"
+        },
+        "description": {
+          "eng": "Located in the rear part of the skiing area on the Oswald-Slope, close to the Waidmann Alpine Cottage, the SNOWPARK MERANO 2000 awaits brave Snowboarders and Freestylers. An ambitious project with many kicks, rails, tubes and boxes for newcomers and pros alike. You can reach the Jump Zone from the mountain station of the Ropeway by using the chairlift Piffing."
+        },
+        "abstract": {
+          "eng": "Located in the rear part of the skiing area on the Oswald-Slope, close to the Waidmann Alpine Cottage, the SNOWPARK MERANO 2000 awaits brave Snowboarders and Freestylers..."
+        },
+        "url": "https://example.com",
+        "length": 1300,
+        "minAltitude": 1500,
+        "maxAltitude": 2500,
+        "address": {
+          "street": null,
+          "city": {
+            "eng": "Merano"
+          },
+          "region": null,
+          "country": "IT",
+          "zipcode": null,
+          "categories": null,
+          "complement": null
+        },
+        "howToArrive": null,
+        "difficulty": "intermediate",
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "snowCondition": {
+          "primarySurface": "frozen-granular",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 30,
+          "baseSnowRange": {
+            "lower": 25,
+            "upper": 40
+          },
+          "latestStorm": 5,
+          "obtainedIn": "2020-01-14",
+          "snowOverNight": 0,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/connections/"
+          }
+        },
+        "features": {
+          "data": [
+            {
+              "type": "features",
+              "id": "example:jib"
+            },
+            {
+              "type": "features",
+              "id": "example:pipe"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/features"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example:free-style"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/snowparks/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mountainAreas.id.json
+++ b/openapi/src/examples/mountainAreas.id.json
@@ -1,0 +1,248 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1"
+  },
+  "included": null,
+  "data": {
+    "id": "1",
+    "type": "mountainAreas",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "name": {
+        "ita": "Merano 2000",
+        "deu": "Meran 2000",
+        "eng": "Meran 2000"
+      },
+      "shortName": {
+        "eng": "Meran 2000"
+      },
+      "description": {
+        "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe. Von Meran aus ist das Gebiet direkt über die Ifinger-Seilbahn ab Naif oder durch eine Umlaufseilbahn ab Falzeben erreichbar. Das Skigebiet erstreckt sich hauptsächlich auf dem Gemeindegebiet von Hafling, berührt aber auch zu den Gemeinden Schenna und Sarntal gehörende Flächen."
+      },
+      "abstract": {
+        "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe."
+      },
+      "url": "https://www.meran2000.com",
+      "geometries": [
+        {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                11.310853958129883,
+                46.66958283253642
+              ],
+              [
+                11.304588317871094,
+                46.668817160723044
+              ],
+              [
+                11.301412582397461,
+                46.666696782172096
+              ],
+              [
+                11.305532455444336,
+                46.66457632044435
+              ],
+              [
+                11.31265640258789,
+                46.66646117942096
+              ],
+              [
+                11.314373016357422,
+                46.66869936409677
+              ],
+              [
+                11.310853958129883,
+                46.66958283253642
+              ]
+            ]
+          ]
+        }
+      ],
+      "howToArrive": {
+        "ita": "L'area sciistica ed escursionistica di Merano è situata ai piedi della montagna Picco Ivigna ed è raggiungibile in pochi minuti dalle destinazioni di Merano, Avelengo, Scena e Tirolo. La cima di Merano 2000 è raggiungibile con due impianti di risalita diversi e ha dunque due stazioni a valle, una presso Merano con la Funivia e una ad Avelengo con la Cabinovia Falzeben.",
+        "deu": "Die Sonnenterrasse Merans liegt am Fuße des Ifingers und ist von den Ferienorten Meran, Hafling, Schenna und Dorf Tirol in wenigen Minuten leicht erreichbar. Die Bergstation von Meran 2000 kann man mit zwei verschiedenen Aufstiegsanlagen erreichen: von Meran aus mit der Bergbahn und von Hafling aus mit der Umlaufbahn Falzeben.",
+        "eng": "The skiing and hiking area of Merano 2000 is best located next to the biggest vacation hotspots of South Tyrol and so reachable within few minutes from Merano, Avelengo, Scena and Tirolo. Two lifts can bring you to the mountain station of Merano 2000: the Ropeway in Merano or the Gondola Falzeben in Avelengo."
+      },
+      "openingHours": {
+        "dailySchedules": {
+          "2020-12-25": null
+        },
+        "weeklySchedules": [
+          {
+            "validFrom": "2020-01-01",
+            "validTo": "2020-12-31",
+            "monday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "tuesday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "wednesday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "thursday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "friday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "saturday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "sunday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ]
+          }
+        ]
+      },
+      "area": 36000,
+      "minAltitude": 1200,
+      "maxAltitude": 2000,
+      "totalTrailLength": 4000,
+      "totalParkArea": 20000,
+      "totalParkLength": 1000,
+      "snowCondition": {
+        "primarySurface": "powder",
+        "secondarySurface": "packed-powder",
+        "baseSnow": 50,
+        "baseSnowRange": {
+          "lower": 40,
+          "upper": 60
+        },
+        "latestStorm": 40,
+        "obtainedIn": "2019-12-20",
+        "snowOverNight": 5,
+        "groomed": true,
+        "snowMaking": false
+      }
+    },
+    "relationships": {
+      "areaOwner": {
+        "data": {
+          "type": "agents",
+          "id": "1"
+        },
+        "links": {
+          "related": "https://example.com/2021-04/mountainAreas/1/areaOwner/"
+        }
+      },
+      "connections": {
+        "data": [
+          {
+            "type": "lifts",
+            "id": "1"
+          },
+          {
+            "type": "skiSlopes",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/mountainAreas/1/connections/"
+        }
+      },
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "example/skiarea"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/mountainAreas/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/mountainAreas/1/multimediaDescriptions/"
+        }
+      },
+      "lifts": {
+        "data": [
+          {
+            "type": "lifts",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/mountainAreas/1/lifts/"
+        }
+      },
+      "skiSlopes": {
+        "data": [
+          {
+            "type": "skiSlopes",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/mountainAreas/1/skiSlopes/"
+        }
+      },
+      "snowparks": {
+        "data": [
+          {
+            "type": "snowparks",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/mountainAreas/1/snowparks/"
+        }
+      },
+      "subAreas": {
+        "data": [
+          {
+            "type": "mountainAreas",
+            "id": "2"
+          },
+          {
+            "type": "mountainAreas",
+            "id": "3"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/mountainAreas/1/subAreas/"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1"
+    }
+  }
+}

--- a/openapi/src/examples/mountainAreas.json
+++ b/openapi/src/examples/mountainAreas.json
@@ -1,0 +1,258 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/mountainAreas?page[number]=2",
+      "prev": "https://example.com/2021-04/mountainAreas?page[number]=1",
+      "first": "https://example.com/2021-04/mountainAreas?page[number]=1",
+      "last": "https://example.com/2021-04/mountainAreas?page[number]=10",
+      "self": "https://example.com/2021-04/mountainAreas"
+  },
+  "included": null,
+  "data": [
+    {
+      "id": "1",
+      "type": "mountainAreas",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Merano 2000",
+          "deu": "Meran 2000",
+          "eng": "Meran 2000"
+        },
+        "shortName": {
+          "eng": "Meran 2000"
+        },
+        "description": {
+          "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe. Von Meran aus ist das Gebiet direkt über die Ifinger-Seilbahn ab Naif oder durch eine Umlaufseilbahn ab Falzeben erreichbar. Das Skigebiet erstreckt sich hauptsächlich auf dem Gemeindegebiet von Hafling, berührt aber auch zu den Gemeinden Schenna und Sarntal gehörende Flächen."
+        },
+        "abstract": {
+          "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe."
+        },
+        "url": "https://www.meran2000.com",
+        "geometries": [
+          {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  11.310853958129883,
+                  46.66958283253642
+                ],
+                [
+                  11.304588317871094,
+                  46.668817160723044
+                ],
+                [
+                  11.301412582397461,
+                  46.666696782172096
+                ],
+                [
+                  11.305532455444336,
+                  46.66457632044435
+                ],
+                [
+                  11.31265640258789,
+                  46.66646117942096
+                ],
+                [
+                  11.314373016357422,
+                  46.66869936409677
+                ],
+                [
+                  11.310853958129883,
+                  46.66958283253642
+                ]
+              ]
+            ]
+          }
+        ],
+        "howToArrive": {
+          "ita": "L'area sciistica ed escursionistica di Merano è situata ai piedi della montagna Picco Ivigna ed è raggiungibile in pochi minuti dalle destinazioni di Merano, Avelengo, Scena e Tirolo. La cima di Merano 2000 è raggiungibile con due impianti di risalita diversi e ha dunque due stazioni a valle, una presso Merano con la Funivia e una ad Avelengo con la Cabinovia Falzeben.",
+          "deu": "Die Sonnenterrasse Merans liegt am Fuße des Ifingers und ist von den Ferienorten Meran, Hafling, Schenna und Dorf Tirol in wenigen Minuten leicht erreichbar. Die Bergstation von Meran 2000 kann man mit zwei verschiedenen Aufstiegsanlagen erreichen: von Meran aus mit der Bergbahn und von Hafling aus mit der Umlaufbahn Falzeben.",
+          "eng": "The skiing and hiking area of Merano 2000 is best located next to the biggest vacation hotspots of South Tyrol and so reachable within few minutes from Merano, Avelengo, Scena and Tirolo. Two lifts can bring you to the mountain station of Merano 2000: the Ropeway in Merano or the Gondola Falzeben in Avelengo."
+        },
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "area": 36000,
+        "minAltitude": 1200,
+        "maxAltitude": 2000,
+        "totalTrailLength": 4000,
+        "totalParkArea": 20000,
+        "totalParkLength": 1000,
+        "snowCondition": {
+          "primarySurface": "powder",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 50,
+          "baseSnowRange": {
+            "lower": 40,
+            "upper": 60
+          },
+          "latestStorm": 40,
+          "obtainedIn": "2019-12-20",
+          "snowOverNight": 5,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "areaOwner": {
+          "data": {
+            "type": "agents",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/areaOwner/"
+          }
+        },
+        "connections": {
+          "data": [
+            {
+              "type": "lifts",
+              "id": "1"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example/skiarea"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/multimediaDescriptions/"
+          }
+        },
+        "lifts": {
+          "data": [
+            {
+              "type": "lifts",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/lifts/"
+          }
+        },
+        "skiSlopes": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/skiSlopes/"
+          }
+        },
+        "snowparks": {
+          "data": [
+            {
+              "type": "snowparks",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/snowparks/"
+          }
+        },
+        "subAreas": {
+          "data": [
+            {
+              "type": "mountainAreas",
+              "id": "2"
+            },
+            {
+              "type": "mountainAreas",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/subAreas/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mountainAreas/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mountainAreas.lifts.json
+++ b/openapi/src/examples/mountainAreas.lifts.json
@@ -1,0 +1,182 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1/lifts"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "lifts",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "deu": "Bergbahn Meran 2000",
+          "eng": "Ropeway Merano 2000",
+          "ita": "Funivia Merano 2000"
+        },
+        "shortName": {
+          "deu": "Meran 2000",
+          "eng": "Merano 2000",
+          "ita": "Merano 2000"
+        },
+        "description": {
+          "ita": "Situata a pochi minuti dalla città di Merano, la Funivia conduce all’area sciistica ed escursionistica Merano 2000, un luogo ideale in cui passare una vacanza all’insegna del movimento e della buona cucina con tutta la famiglia. Grazie al suo clima mite, l’area offre infinite possibilità per il tempo libero in ogni stagione: impianti di risalita, sentieri escursionistici facili e numerosi rifugi in cui sostare per assaporare l’ottima cucina locale in un paesaggio ricco e dominato dalla tranquillità."
+        },
+        "abstract": {
+          "ita": "Situata a pochi minuti dalla città di Merano, la Funivia conduce all’area sciistica ed escursionistica Merano 2000, un luogo ideale in cui passare una vacanza all’insegna del movimento e della buona cucina con tutta la famiglia..."
+        },
+        "url": "https://example.com",
+        "length": 3650,
+        "minAltitude": 1000,
+        "maxAltitude": 2350,
+        "capacity": 200,
+        "personsPerChair": 10,
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "address": {
+          "street": {
+            "deu": "Naifweg 37",
+            "eng": "37 Val di Nova Street",
+            "ita": "Via Val di Nova, 37"
+          },
+          "city": {
+            "deu": "Meran",
+            "eng": "Merano",
+            "ita": "Merano"
+          },
+          "region": {
+            "deu": "Trentino-Südtirol",
+            "eng": "Trentino-Alto Adige",
+            "ita": "Trentino-Alto Adige"
+          },
+          "country": "IT",
+          "zipcode": "39012",
+          "categories": null,
+          "complement": null
+        },
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "howToArrive": {
+          "ita": "Fino alla stazione a valle della Funivia Merano 2000: dalla stazione ferroviaria di Merano si raggiunge in pochi minuti la stazione a valle Val di Nova con la linea urbana 1A. Da Scena c'è il bus vacanze che porta fino alla Val di Nova.",
+          "deu": "Zur Talstation der Bergbahn Meran 2000: vom Zugbahnhof Meran erreicht man in wenigen Minuten die Talstation Naif mit der Buslinie 1A. Von Schenna aus fährt der Gästebus bis zur Talstation Naif."
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:cablecar"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/lifts/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/lifts/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mountainAreas.multimediaDescriptions.json
+++ b/openapi/src/examples/mountainAreas.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mountainAreas.skiSlopes.json
+++ b/openapi/src/examples/mountainAreas.skiSlopes.json
@@ -1,0 +1,193 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1/skiSlopes"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "skiSlopes",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Falzeben I",
+          "deu": "Falzeben I",
+          "eng": "Falzeben I"
+        },
+        "shortName": {
+          "ita": "Falzeben I"
+        },
+        "description": {
+          "ita": "Falzeben I -  Discesa tra i boschi facile, immersa in un panorama da sogno ed ideale per bambini e principianti. Altezza/Lunghezza: 1900 altezza, 3500 m."
+        },
+        "abstract": {
+          "ita": "Falzeben I -  Discesa tra i boschi facile, immersa in un panorama da sogno ed ideale per bambini e principianti."
+        },
+        "url": "https://example.com",
+        "length": 2000,
+        "minAltitude": 1500,
+        "maxAltitude": 2500,
+        "difficulty": {
+          "eu": "novice",
+          "us": "beginner"
+        },
+        "address": {
+          "street": null,
+          "city": {
+            "eng": "Merano"
+          },
+          "region": null,
+          "country": "IT",
+          "zipcode": null,
+          "categories": null,
+          "complement": null
+        },
+        "howToArrive": {
+          "ita": " Le fermate più vicine a Falzeben sono: Falzeben è a 41 metri di distanza a piedi e ci si arriva in 1 minuti di cammino; Villa Schäfer è a 808 metri di distanza a piedi e ci si arriva in 11 minuti di cammino."
+        },
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "snowCondition": {
+          "primarySurface": "powder",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 50,
+          "baseSnowRange": {
+            "lower": 40,
+            "upper": 60
+          },
+          "latestStorm": 40,
+          "obtainedIn": "2020-02-01",
+          "snowOverNight": 5,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "3"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "4"
+            },
+            {
+              "type": "lifts",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:standard-ski-slope"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/skiSlopes/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mountainAreas.snowparks.json
+++ b/openapi/src/examples/mountainAreas.snowparks.json
@@ -1,0 +1,195 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1/snowparks"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "snowparks",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Snowpark Merano 2000",
+          "deu": "Snowpark Merano 2000",
+          "eng": "Snowpark Merano 2000"
+        },
+        "shortName": {
+          "eng": "Snowpark Merano 2000"
+        },
+        "description": {
+          "eng": "Located in the rear part of the skiing area on the Oswald-Slope, close to the Waidmann Alpine Cottage, the SNOWPARK MERANO 2000 awaits brave Snowboarders and Freestylers. An ambitious project with many kicks, rails, tubes and boxes for newcomers and pros alike. You can reach the Jump Zone from the mountain station of the Ropeway by using the chairlift Piffing."
+        },
+        "abstract": {
+          "eng": "Located in the rear part of the skiing area on the Oswald-Slope, close to the Waidmann Alpine Cottage, the SNOWPARK MERANO 2000 awaits brave Snowboarders and Freestylers..."
+        },
+        "url": "https://example.com",
+        "length": 1300,
+        "minAltitude": 1500,
+        "maxAltitude": 2500,
+        "address": {
+          "street": null,
+          "city": {
+            "eng": "Merano"
+          },
+          "region": null,
+          "country": "IT",
+          "zipcode": null,
+          "categories": null,
+          "complement": null
+        },
+        "howToArrive": null,
+        "difficulty": "intermediate",
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "snowCondition": {
+          "primarySurface": "frozen-granular",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 30,
+          "baseSnowRange": {
+            "lower": 25,
+            "upper": 40
+          },
+          "latestStorm": 5,
+          "obtainedIn": "2020-01-14",
+          "snowOverNight": 0,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/connections/"
+          }
+        },
+        "features": {
+          "data": [
+            {
+              "type": "features",
+              "id": "example:jib"
+            },
+            {
+              "type": "features",
+              "id": "example:pipe"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/features"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example:free-style"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/snowparks/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/mountainAreas.subAreas.json
+++ b/openapi/src/examples/mountainAreas.subAreas.json
@@ -1,0 +1,51 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/mountainAreas/1/subAreas"
+  },
+  "included": null,
+  "data": [
+    {
+      "id": "2",
+      "type": "mountainAreas",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "name": {
+          "eng": "Meran 2000"
+        },
+        "shortName": null,
+        "description": null,
+        "abstract": null,
+        "url": null,
+        "geometries": null,
+        "howToArrive": null,
+        "openingHours": null,
+        "area": null,
+        "minAltitude": null,
+        "maxAltitude": null,
+        "totalTrailLength": null,
+        "totalParkArea": null,
+        "totalParkLength": null,
+        "snowCondition": null
+      },
+      "relationships": {
+        "areaOwner": null,
+        "connections": null,
+        "categories": null,
+        "multimediaDescriptions": null,
+        "lifts": null,
+        "skiSlopes": null,
+        "snowparks": null,
+        "subAreas": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mountainAreas/2"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/skiSlopes.categories.json
+++ b/openapi/src/examples/skiSlopes.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/skiSlopes/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:category",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "skiSlopes" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:category",
+        "resources": {
+          "skiSlopes": "https://example.com/2021-04/skiSlopes?filter[categories][any]=example:category"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/skiSlopes.connections.json
+++ b/openapi/src/examples/skiSlopes.connections.json
@@ -1,0 +1,250 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/skiSlopes/1/connections"
+  },
+  "included": null,
+  "data": [
+    {
+      "id": "1",
+      "type": "mountainAreas",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Merano 2000",
+          "deu": "Meran 2000",
+          "eng": "Meran 2000"
+        },
+        "shortName": {
+          "eng": "Meran 2000"
+        },
+        "description": {
+          "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe. Von Meran aus ist das Gebiet direkt über die Ifinger-Seilbahn ab Naif oder durch eine Umlaufseilbahn ab Falzeben erreichbar. Das Skigebiet erstreckt sich hauptsächlich auf dem Gemeindegebiet von Hafling, berührt aber auch zu den Gemeinden Schenna und Sarntal gehörende Flächen."
+        },
+        "abstract": {
+          "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe."
+        },
+        "url": "https://www.meran2000.com",
+        "geometries": [
+          {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  11.310853958129883,
+                  46.66958283253642
+                ],
+                [
+                  11.304588317871094,
+                  46.668817160723044
+                ],
+                [
+                  11.301412582397461,
+                  46.666696782172096
+                ],
+                [
+                  11.305532455444336,
+                  46.66457632044435
+                ],
+                [
+                  11.31265640258789,
+                  46.66646117942096
+                ],
+                [
+                  11.314373016357422,
+                  46.66869936409677
+                ],
+                [
+                  11.310853958129883,
+                  46.66958283253642
+                ]
+              ]
+            ]
+          }
+        ],
+        "howToArrive": {
+          "ita": "L'area sciistica ed escursionistica di Merano è situata ai piedi della montagna Picco Ivigna ed è raggiungibile in pochi minuti dalle destinazioni di Merano, Avelengo, Scena e Tirolo. La cima di Merano 2000 è raggiungibile con due impianti di risalita diversi e ha dunque due stazioni a valle, una presso Merano con la Funivia e una ad Avelengo con la Cabinovia Falzeben.",
+          "deu": "Die Sonnenterrasse Merans liegt am Fuße des Ifingers und ist von den Ferienorten Meran, Hafling, Schenna und Dorf Tirol in wenigen Minuten leicht erreichbar. Die Bergstation von Meran 2000 kann man mit zwei verschiedenen Aufstiegsanlagen erreichen: von Meran aus mit der Bergbahn und von Hafling aus mit der Umlaufbahn Falzeben.",
+          "eng": "The skiing and hiking area of Merano 2000 is best located next to the biggest vacation hotspots of South Tyrol and so reachable within few minutes from Merano, Avelengo, Scena and Tirolo. Two lifts can bring you to the mountain station of Merano 2000: the Ropeway in Merano or the Gondola Falzeben in Avelengo."
+        },
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "area": 36000,
+        "minAltitude": 1200,
+        "maxAltitude": 2000,
+        "totalTrailLength": 4000,
+        "totalParkArea": 20000,
+        "totalParkLength": 1000,
+        "snowCondition": {
+          "primarySurface": "powder",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 50,
+          "baseSnowRange": {
+            "lower": 40,
+            "upper": 60
+          },
+          "latestStorm": 40,
+          "obtainedIn": "2019-12-20",
+          "snowOverNight": 5,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "areaOwner": {
+          "data": {
+            "type": "agents",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/areaOwner/"
+          }
+        },
+        "connections": {
+          "data": [
+            {
+              "type": "lifts",
+              "id": "1"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example/skiarea"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/multimediaDescriptions/"
+          }
+        },
+        "lifts": {
+          "data": [
+            {
+              "type": "lifts",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/lifts/"
+          }
+        },
+        "skiSlopes": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/skiSlopes/"
+          }
+        },
+        "snowparks": {
+          "data": [
+            {
+              "type": "snowparks",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/snowparks/"
+          }
+        },
+        "subAreas": {
+          "data": [
+            {
+              "type": "mountainAreas",
+              "id": "2"
+            },
+            {
+              "type": "mountainAreas",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/subAreas/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mountainAreas/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/skiSlopes.id.json
+++ b/openapi/src/examples/skiSlopes.id.json
@@ -1,0 +1,191 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/skiSlopes/1"
+  },
+  "included": null,
+  "data": {
+    "type": "skiSlopes",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "name": {
+        "ita": "Falzeben I",
+        "deu": "Falzeben I",
+        "eng": "Falzeben I"
+      },
+      "shortName": {
+        "ita": "Falzeben I"
+      },
+      "description": {
+        "ita": "Falzeben I -  Discesa tra i boschi facile, immersa in un panorama da sogno ed ideale per bambini e principianti. Altezza/Lunghezza: 1900 altezza, 3500 m."
+      },
+      "abstract": {
+        "ita": "Falzeben I -  Discesa tra i boschi facile, immersa in un panorama da sogno ed ideale per bambini e principianti."
+      },
+      "url": "https://example.com",
+      "length": 2000,
+      "minAltitude": 1500,
+      "maxAltitude": 2500,
+      "difficulty": {
+        "eu": "novice",
+        "us": "beginner"
+      },
+      "address": {
+        "street": null,
+        "city": {
+          "eng": "Merano"
+        },
+        "region": null,
+        "country": "IT",
+        "zipcode": null,
+        "categories": null,
+        "complement": null
+      },
+      "howToArrive": {
+        "ita": " Le fermate più vicine a Falzeben sono: Falzeben è a 41 metri di distanza a piedi e ci si arriva in 1 minuti di cammino; Villa Schäfer è a 808 metri di distanza a piedi e ci si arriva in 11 minuti di cammino."
+      },
+      "geometries": [
+        {
+          "type": "LineString",
+          "coordinates": [
+            [
+              11.305682659149168,
+              46.66705018437341
+            ],
+            [
+              11.30692720413208,
+              46.667182709603225
+            ],
+            [
+              11.308064460754393,
+              46.667491933875965
+            ]
+          ]
+        }
+      ],
+      "openingHours": {
+        "dailySchedules": {
+          "2020-12-25": null
+        },
+        "weeklySchedules": [
+          {
+            "validFrom": "2020-01-01",
+            "validTo": "2020-12-31",
+            "monday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "tuesday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "wednesday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "thursday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "friday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "saturday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "sunday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ]
+          }
+        ]
+      },
+      "snowCondition": {
+        "primarySurface": "powder",
+        "secondarySurface": "packed-powder",
+        "baseSnow": 50,
+        "baseSnowRange": {
+          "lower": 40,
+          "upper": 60
+        },
+        "latestStorm": 40,
+        "obtainedIn": "2020-02-01",
+        "snowOverNight": 5,
+        "groomed": true,
+        "snowMaking": false
+      }
+    },
+    "relationships": {
+      "connections": {
+        "data": [
+          {
+            "type": "skiSlopes",
+            "id": "2"
+          },
+          {
+            "type": "skiSlopes",
+            "id": "3"
+          },
+          {
+            "type": "skiSlopes",
+            "id": "4"
+          },
+          {
+            "type": "lifts",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/skiSlopes/1/connections/"
+        }
+      },
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "alpinebits:standard-ski-slope"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/skiSlopes/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "2"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/skiSlopes/1/multimediaDescriptions/"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/skiSlopes/1"
+    }
+  }
+}

--- a/openapi/src/examples/skiSlopes.json
+++ b/openapi/src/examples/skiSlopes.json
@@ -1,0 +1,201 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/skiSlopes?page[number]=2",
+      "prev": "https://example.com/2021-04/skiSlopes?page[number]=1",
+      "first": "https://example.com/2021-04/skiSlopes?page[number]=1",
+      "last": "https://example.com/2021-04/skiSlopes?page[number]=10",
+      "self": "https://example.com/2021-04/skiSlopes"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "skiSlopes",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Falzeben I",
+          "deu": "Falzeben I",
+          "eng": "Falzeben I"
+        },
+        "shortName": {
+          "ita": "Falzeben I"
+        },
+        "description": {
+          "ita": "Falzeben I -  Discesa tra i boschi facile, immersa in un panorama da sogno ed ideale per bambini e principianti. Altezza/Lunghezza: 1900 altezza, 3500 m."
+        },
+        "abstract": {
+          "ita": "Falzeben I -  Discesa tra i boschi facile, immersa in un panorama da sogno ed ideale per bambini e principianti."
+        },
+        "url": "https://example.com",
+        "length": 2000,
+        "minAltitude": 1500,
+        "maxAltitude": 2500,
+        "difficulty": {
+          "eu": "novice",
+          "us": "beginner"
+        },
+        "address": {
+          "street": null,
+          "city": {
+            "eng": "Merano"
+          },
+          "region": null,
+          "country": "IT",
+          "zipcode": null,
+          "categories": null,
+          "complement": null
+        },
+        "howToArrive": {
+          "ita": " Le fermate più vicine a Falzeben sono: Falzeben è a 41 metri di distanza a piedi e ci si arriva in 1 minuti di cammino; Villa Schäfer è a 808 metri di distanza a piedi e ci si arriva in 11 minuti di cammino."
+        },
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "snowCondition": {
+          "primarySurface": "powder",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 50,
+          "baseSnowRange": {
+            "lower": 40,
+            "upper": 60
+          },
+          "latestStorm": 40,
+          "obtainedIn": "2020-02-01",
+          "snowOverNight": 5,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "3"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "4"
+            },
+            {
+              "type": "lifts",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "alpinebits:standard-ski-slope"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/skiSlopes/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/skiSlopes/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/skiSlopes.multimediaDescriptions.json
+++ b/openapi/src/examples/skiSlopes.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/skiSlopes/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/snowparks.categories.json
+++ b/openapi/src/examples/snowparks.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/snowparks/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:category",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "snowparks" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:category",
+        "resources": {
+          "snowparks": "https://example.com/2021-04/snowparks?filter[categories][any]=example:category"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/snowparks.connections.json
+++ b/openapi/src/examples/snowparks.connections.json
@@ -1,0 +1,250 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/snowparks/1/connections"
+  },
+  "included": null,
+  "data": [
+    {
+      "id": "1",
+      "type": "mountainAreas",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Merano 2000",
+          "deu": "Meran 2000",
+          "eng": "Meran 2000"
+        },
+        "shortName": {
+          "eng": "Meran 2000"
+        },
+        "description": {
+          "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe. Von Meran aus ist das Gebiet direkt über die Ifinger-Seilbahn ab Naif oder durch eine Umlaufseilbahn ab Falzeben erreichbar. Das Skigebiet erstreckt sich hauptsächlich auf dem Gemeindegebiet von Hafling, berührt aber auch zu den Gemeinden Schenna und Sarntal gehörende Flächen."
+        },
+        "abstract": {
+          "deu": "Das Skigebiet Meran 2000 liegt unter dem Berg Ifinger im Burggrafenamt auf einem Hochplateau oberhalb Meran am Tschögglberg in Südtirol. Es hat 45 km Alpin-Pisten und reicht von 1670 bis 2300 m Höhe."
+        },
+        "url": "https://www.meran2000.com",
+        "geometries": [
+          {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  11.310853958129883,
+                  46.66958283253642
+                ],
+                [
+                  11.304588317871094,
+                  46.668817160723044
+                ],
+                [
+                  11.301412582397461,
+                  46.666696782172096
+                ],
+                [
+                  11.305532455444336,
+                  46.66457632044435
+                ],
+                [
+                  11.31265640258789,
+                  46.66646117942096
+                ],
+                [
+                  11.314373016357422,
+                  46.66869936409677
+                ],
+                [
+                  11.310853958129883,
+                  46.66958283253642
+                ]
+              ]
+            ]
+          }
+        ],
+        "howToArrive": {
+          "ita": "L'area sciistica ed escursionistica di Merano è situata ai piedi della montagna Picco Ivigna ed è raggiungibile in pochi minuti dalle destinazioni di Merano, Avelengo, Scena e Tirolo. La cima di Merano 2000 è raggiungibile con due impianti di risalita diversi e ha dunque due stazioni a valle, una presso Merano con la Funivia e una ad Avelengo con la Cabinovia Falzeben.",
+          "deu": "Die Sonnenterrasse Merans liegt am Fuße des Ifingers und ist von den Ferienorten Meran, Hafling, Schenna und Dorf Tirol in wenigen Minuten leicht erreichbar. Die Bergstation von Meran 2000 kann man mit zwei verschiedenen Aufstiegsanlagen erreichen: von Meran aus mit der Bergbahn und von Hafling aus mit der Umlaufbahn Falzeben.",
+          "eng": "The skiing and hiking area of Merano 2000 is best located next to the biggest vacation hotspots of South Tyrol and so reachable within few minutes from Merano, Avelengo, Scena and Tirolo. Two lifts can bring you to the mountain station of Merano 2000: the Ropeway in Merano or the Gondola Falzeben in Avelengo."
+        },
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "area": 36000,
+        "minAltitude": 1200,
+        "maxAltitude": 2000,
+        "totalTrailLength": 4000,
+        "totalParkArea": 20000,
+        "totalParkLength": 1000,
+        "snowCondition": {
+          "primarySurface": "powder",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 50,
+          "baseSnowRange": {
+            "lower": 40,
+            "upper": 60
+          },
+          "latestStorm": 40,
+          "obtainedIn": "2019-12-20",
+          "snowOverNight": 5,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "areaOwner": {
+          "data": {
+            "type": "agents",
+            "id": "1"
+          },
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/areaOwner/"
+          }
+        },
+        "connections": {
+          "data": [
+            {
+              "type": "lifts",
+              "id": "1"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/connections/"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example/skiarea"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/multimediaDescriptions/"
+          }
+        },
+        "lifts": {
+          "data": [
+            {
+              "type": "lifts",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/lifts/"
+          }
+        },
+        "skiSlopes": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/skiSlopes/"
+          }
+        },
+        "snowparks": {
+          "data": [
+            {
+              "type": "snowparks",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/snowparks/"
+          }
+        },
+        "subAreas": {
+          "data": [
+            {
+              "type": "mountainAreas",
+              "id": "2"
+            },
+            {
+              "type": "mountainAreas",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/mountainAreas/1/subAreas/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mountainAreas/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/snowparks.features.json
+++ b/openapi/src/examples/snowparks.features.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/snowparks/1/features"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "features",
+      "id": "example:feature",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Feature"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "snowparks" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/features/example:feature",
+        "resources": {
+          "snowparks": "https://example.com/2021-04/snowparks?filter[features][any]=example:feature"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/snowparks.id.json
+++ b/openapi/src/examples/snowparks.id.json
@@ -1,0 +1,193 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/snowparks/1"
+  },
+  "included": null,
+  "data": {
+    "type": "snowparks",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "name": {
+        "ita": "Snowpark Merano 2000",
+        "deu": "Snowpark Merano 2000",
+        "eng": "Snowpark Merano 2000"
+      },
+      "shortName": {
+        "eng": "Snowpark Merano 2000"
+      },
+      "description": {
+        "eng": "Located in the rear part of the skiing area on the Oswald-Slope, close to the Waidmann Alpine Cottage, the SNOWPARK MERANO 2000 awaits brave Snowboarders and Freestylers. An ambitious project with many kicks, rails, tubes and boxes for newcomers and pros alike. You can reach the Jump Zone from the mountain station of the Ropeway by using the chairlift Piffing."
+      },
+      "abstract": {
+        "eng": "Located in the rear part of the skiing area on the Oswald-Slope, close to the Waidmann Alpine Cottage, the SNOWPARK MERANO 2000 awaits brave Snowboarders and Freestylers..."
+      },
+      "url": "https://example.com",
+      "length": 1300,
+      "minAltitude": 1500,
+      "maxAltitude": 2500,
+      "address": {
+        "street": null,
+        "city": {
+          "eng": "Merano"
+        },
+        "region": null,
+        "country": "IT",
+        "zipcode": null,
+        "categories": null,
+        "complement": null
+      },
+      "howToArrive": null,
+      "difficulty": "intermediate",
+      "geometries": [
+        {
+          "type": "LineString",
+          "coordinates": [
+            [
+              11.305682659149168,
+              46.66705018437341
+            ],
+            [
+              11.30692720413208,
+              46.667182709603225
+            ],
+            [
+              11.308064460754393,
+              46.667491933875965
+            ]
+          ]
+        }
+      ],
+      "openingHours": {
+        "dailySchedules": {
+          "2020-12-25": null
+        },
+        "weeklySchedules": [
+          {
+            "validFrom": "2020-01-01",
+            "validTo": "2020-12-31",
+            "monday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "tuesday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "wednesday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "thursday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "friday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "saturday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ],
+            "sunday": [
+              {
+                "opens": "08:00:00+01:00",
+                "closes": "18:00:00+01:00"
+              }
+            ]
+          }
+        ]
+      },
+      "snowCondition": {
+        "primarySurface": "frozen-granular",
+        "secondarySurface": "packed-powder",
+        "baseSnow": 30,
+        "baseSnowRange": {
+          "lower": 25,
+          "upper": 40
+        },
+        "latestStorm": 5,
+        "obtainedIn": "2020-01-14",
+        "snowOverNight": 0,
+        "groomed": true,
+        "snowMaking": false
+      }
+    },
+    "relationships": {
+      "connections": {
+        "data": [
+          {
+            "type": "skiSlopes",
+            "id": "2"
+          },
+          {
+            "type": "skiSlopes",
+            "id": "3"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/snowparks/1/connections/"
+        }
+      },
+      "features": {
+        "data": [
+          {
+            "type": "features",
+            "id": "example:jib"
+          },
+          {
+            "type": "features",
+            "id": "example:pipe"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/snowparks/1/features"
+        }
+      },
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "example:free-style"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/snowparks/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "2"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/snowparks/1/multimediaDescriptions/"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/snowparks/1"
+    }
+  }
+}

--- a/openapi/src/examples/snowparks.json
+++ b/openapi/src/examples/snowparks.json
@@ -1,0 +1,203 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/snowparks?page[number]=2",
+      "prev": "https://example.com/2021-04/snowparks?page[number]=1",
+      "first": "https://example.com/2021-04/snowparks?page[number]=1",
+      "last": "https://example.com/2021-04/snowparks?page[number]=10",
+      "self": "https://example.com/2021-04/snowparks"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "snowparks",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "name": {
+          "ita": "Snowpark Merano 2000",
+          "deu": "Snowpark Merano 2000",
+          "eng": "Snowpark Merano 2000"
+        },
+        "shortName": {
+          "eng": "Snowpark Merano 2000"
+        },
+        "description": {
+          "eng": "Located in the rear part of the skiing area on the Oswald-Slope, close to the Waidmann Alpine Cottage, the SNOWPARK MERANO 2000 awaits brave Snowboarders and Freestylers. An ambitious project with many kicks, rails, tubes and boxes for newcomers and pros alike. You can reach the Jump Zone from the mountain station of the Ropeway by using the chairlift Piffing."
+        },
+        "abstract": {
+          "eng": "Located in the rear part of the skiing area on the Oswald-Slope, close to the Waidmann Alpine Cottage, the SNOWPARK MERANO 2000 awaits brave Snowboarders and Freestylers..."
+        },
+        "url": "https://example.com",
+        "length": 1300,
+        "minAltitude": 1500,
+        "maxAltitude": 2500,
+        "address": {
+          "street": null,
+          "city": {
+            "eng": "Merano"
+          },
+          "region": null,
+          "country": "IT",
+          "zipcode": null,
+          "categories": null,
+          "complement": null
+        },
+        "howToArrive": null,
+        "difficulty": "intermediate",
+        "geometries": [
+          {
+            "type": "LineString",
+            "coordinates": [
+              [
+                11.305682659149168,
+                46.66705018437341
+              ],
+              [
+                11.30692720413208,
+                46.667182709603225
+              ],
+              [
+                11.308064460754393,
+                46.667491933875965
+              ]
+            ]
+          }
+        ],
+        "openingHours": {
+          "dailySchedules": {
+            "2020-12-25": null
+          },
+          "weeklySchedules": [
+            {
+              "validFrom": "2020-01-01",
+              "validTo": "2020-12-31",
+              "monday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "tuesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "wednesday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "thursday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "friday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "saturday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ],
+              "sunday": [
+                {
+                  "opens": "08:00:00+01:00",
+                  "closes": "18:00:00+01:00"
+                }
+              ]
+            }
+          ]
+        },
+        "snowCondition": {
+          "primarySurface": "frozen-granular",
+          "secondarySurface": "packed-powder",
+          "baseSnow": 30,
+          "baseSnowRange": {
+            "lower": 25,
+            "upper": 40
+          },
+          "latestStorm": 5,
+          "obtainedIn": "2020-01-14",
+          "snowOverNight": 0,
+          "groomed": true,
+          "snowMaking": false
+        }
+      },
+      "relationships": {
+        "connections": {
+          "data": [
+            {
+              "type": "skiSlopes",
+              "id": "2"
+            },
+            {
+              "type": "skiSlopes",
+              "id": "3"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/connections/"
+          }
+        },
+        "features": {
+          "data": [
+            {
+              "type": "features",
+              "id": "example:jib"
+            },
+            {
+              "type": "features",
+              "id": "example:pipe"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/features"
+          }
+        },
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example:free-style"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "2"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/snowparks/1/multimediaDescriptions/"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/snowparks/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/snowparks.multimediaDescriptions.json
+++ b/openapi/src/examples/snowparks.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/snowparks/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/venues.categories.json
+++ b/openapi/src/examples/venues.categories.json
@@ -1,0 +1,41 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/snowparks/1/categories"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "categories",
+      "id": "example:category",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "description": null,
+        "name": {
+          "eng": "Example Category"
+        },
+        "namespace": "example",
+        "resourceTypes": [ "snowparks" ],
+        "shortName": null,
+        "url": null
+      },
+      "relationships": {
+        "children": null,
+        "multimediaDescriptions": null,
+        "parents": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/categories/example:category",
+        "resources": {
+          "snowparks": "https://example.com/2021-04/snowparks?filter[categories][any]=example:category"
+        }
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/venues.id.json
+++ b/openapi/src/examples/venues.id.json
@@ -1,0 +1,92 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/venues/1"
+  },
+  "included": null,
+  "data": {
+    "type": "venues",
+    "id": "1",
+    "meta": {
+      "dataProvider": "https://example.com",
+      "lastUpdate": "2020-04-01T08:00:00+02:00"
+    },
+    "attributes": {
+      "abstract": {
+        "eng": "The Auditorium 1 of the Free University of Bozen-Bolzano provides a great space for keynotes, lectures and presentations."
+      },
+      "address": {
+        "street": {
+          "ita": "Piazza Università, 1",
+          "deu": "Universitätsplatz 1"
+        },
+        "city": {
+          "deu": "Bozen"
+        },
+        "region": {
+          "deu": "Trentino-Südtirol"
+        },
+        "country": "IT",
+        "zipcode": "39100",
+        "complement": {
+          "deu": "Hauptgebäude"
+        },
+        "categories": [
+          "example/building"
+        ]
+      },
+      "area": 150,
+      "description": {
+        "eng": "The Auditorium 1 of the Free University of Bozen-Bolzano provides a great space for keynotes, lectures and presentations, being available to host events related academic, provincial and cultural topics."
+      },
+      "geometries": [
+        {
+          "type": "Point",
+          "coordinates": [
+            11.35087251663208,
+            46.49873937419277
+          ]
+        }
+      ],
+      "howToArrive": {
+        "eng": "From the train station, the Free University of Bozen-Bolzano is accessible in a 5 minutes walk into the historical city center."
+      },
+      "name": {
+        "eng": "Auditorium 1 - Free University of Bozen-Bolzano"
+      },
+      "shortName": {
+        "eng": "Auditorium 1"
+      },
+      "url": "https://example.com/auditorium-1"
+    },
+    "relationships": {
+      "categories": {
+        "data": [
+          {
+            "type": "categories",
+            "id": "example:auditorium"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/venues/1/categories"
+        }
+      },
+      "multimediaDescriptions": {
+        "data": [
+          {
+            "type": "mediaObjects",
+            "id": "1"
+          }
+        ],
+        "links": {
+          "related": "https://example.com/2021-04/venues/1/multimediaDescriptions"
+        }
+      }
+    },
+    "links": {
+      "self": "https://example.com/2021-04/venues/1"
+    }
+  }
+}

--- a/openapi/src/examples/venues.json
+++ b/openapi/src/examples/venues.json
@@ -1,0 +1,102 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "meta": {
+    "count": 10,
+    "pages": 10
+  },
+  "links": {
+      "next": "https://example.com/2021-04/vennues?page[number]=2",
+      "prev": "https://example.com/2021-04/vennues?page[number]=1",
+      "first": "https://example.com/2021-04/vennues?page[number]=1",
+      "last": "https://example.com/2021-04/vennues?page[number]=10",
+      "self": "https://example.com/2021-04/vennues"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "venues",
+      "id": "1",
+      "meta": {
+        "dataProvider": "https://example.com",
+        "lastUpdate": "2020-04-01T08:00:00+02:00"
+      },
+      "attributes": {
+        "abstract": {
+          "eng": "The Auditorium 1 of the Free University of Bozen-Bolzano provides a great space for keynotes, lectures and presentations."
+        },
+        "address": {
+          "street": {
+            "ita": "Piazza Università, 1",
+            "deu": "Universitätsplatz 1"
+          },
+          "city": {
+            "deu": "Bozen"
+          },
+          "region": {
+            "deu": "Trentino-Südtirol"
+          },
+          "country": "IT",
+          "zipcode": "39100",
+          "complement": {
+            "deu": "Hauptgebäude"
+          },
+          "categories": [
+            "example/building"
+          ]
+        },
+        "area": 150,
+        "description": {
+          "eng": "The Auditorium 1 of the Free University of Bozen-Bolzano provides a great space for keynotes, lectures and presentations, being available to host events related academic, provincial and cultural topics."
+        },
+        "geometries": [
+          {
+            "type": "Point",
+            "coordinates": [
+              11.35087251663208,
+              46.49873937419277
+            ]
+          }
+        ],
+        "howToArrive": {
+          "eng": "From the train station, the Free University of Bozen-Bolzano is accessible in a 5 minutes walk into the historical city center."
+        },
+        "name": {
+          "eng": "Auditorium 1 - Free University of Bozen-Bolzano"
+        },
+        "shortName": {
+          "eng": "Auditorium 1"
+        },
+        "url": "https://example.com/auditorium-1"
+      },
+      "relationships": {
+        "categories": {
+          "data": [
+            {
+              "type": "categories",
+              "id": "example:auditorium"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/venues/1/categories"
+          }
+        },
+        "multimediaDescriptions": {
+          "data": [
+            {
+              "type": "mediaObjects",
+              "id": "1"
+            }
+          ],
+          "links": {
+            "related": "https://example.com/2021-04/venues/1/multimediaDescriptions"
+          }
+        }
+      },
+      "links": {
+        "self": "https://example.com/2021-04/venues/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/examples/venues.multimediaDescriptions.json
+++ b/openapi/src/examples/venues.multimediaDescriptions.json
@@ -1,0 +1,38 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+      "self": "https://example.com/2021-04/venues/1/multimediaDescriptions"
+  },
+  "included": null,
+  "data": [
+    {
+      "type": "mediaObjects",
+      "id": "1",
+      "meta": {
+        "dataProvider": null,
+        "lastUpdate": null
+      },
+      "attributes": {
+        "abstract": null,
+        "contentType": "audio/mpeg3",
+        "description": null,
+        "duration": null,
+        "height": null,
+        "license": null,
+        "name": null,
+        "shortName": null,
+        "url": "https://example.com/audio.mp3",
+        "width": null
+      },
+      "relationships": {
+        "categories": null,
+        "copyrightOwner": null
+      },
+      "links": {
+        "self": "https://example.com/2021-04/mediaObjects/1"
+      }
+    }
+  ]
+}

--- a/openapi/src/index.yml
+++ b/openapi/src/index.yml
@@ -1,0 +1,194 @@
+openapi: '3.0.3'
+externalDocs:
+  url: https://www.alpinebits.org/destinationdata/
+info:
+  title: AlpineBits DestinationData Reference Server
+  version: '2021-04'
+  license:
+    name: GPLv3
+  description: The AlpineBits DestinationData is an standard for the exchange of
+    data in the alpine tourism sector through REST APIs. This standard relies on
+    well-defined and widely adopted standards, such as JSON Schema, JSON:API,
+    and GeoJSON, to offer a high-quality API design. This document presents an
+    OpenAPI-based documentation of the AlpineBits DestinationData standard. It
+    is intended as a start point for server and client developers to the
+    standard itself and can used by server developers to provide documentation
+    tailored for their implementations.
+  contact:
+    name: AlpineBits Alliance (Editorial)
+    email: info@alpinebits.org
+servers:
+  - url: https://destinationdata.alpinebits.opendatahub.bz.it/
+    description: OpenDataHub Server
+  - url: https://example.com/
+    description: Example Server URL
+tags:
+  - name: Base
+    description: Requests to base endpoints
+  # - name: Agents
+  #   description: Requests to resources of type `agents` and related
+  - name: Categories
+    description: Requests to resources of type `categories` and related
+  - name: Events
+    description: Requests to resources of type `events` and related
+  # - name: Event Series
+  #   description: Requests to resources of type `eventSeries` and related
+  - name: Features
+    description: Requests to resources of type `features` and related
+  - name: Lifts
+    description: Requests to resources of type `lifts` and related
+  # - name: Media Objects
+  #   description: Requests to resources of type `mediaObjects` and related
+  - name: Mountain Areas
+    description: Requests to resources of type `mountainAreas` and related
+  - name: Ski Slopes
+    description: Requests to resources of type `skiSlopes` and related
+  - name: Snowparks
+    description: Requests to resources of type `snowparks` and related
+  # - name: Venues
+  #   description: Requests to resources of type `venues` and related
+  
+paths:
+  /:
+    $ref: route.base.yml#/base
+  /2021-04:
+    $ref: route.base.yml#/2021-04
+
+  # /2021-04/agents:
+  #   $ref: route.agents.yml#/base
+  # /2021-04/agents/{id}:
+  #   $ref: route.agents.yml#/id
+  # /2021-04/agents/{id}/categories:
+  #   $ref: route.agents.yml#/categories
+  # /2021-04/agents/{id}/multimediaDescriptions:
+  #   $ref: route.agents.yml#/multimediaDescriptions
+    
+  /2021-04/categories:
+    $ref: route.categories.yml#/base
+  /2021-04/categories/{id}:
+    $ref: route.categories.yml#/id
+  /2021-04/categories/{id}/children:
+    $ref: route.categories.yml#/children
+  /2021-04/categories/{id}/multimediaDescriptions:
+    $ref: route.categories.yml#/multimediaDescriptions
+  /2021-04/categories/{id}/parents:
+    $ref: route.categories.yml#/parents
+    
+  /2021-04/events:
+    $ref: route.events.yml#/base
+  /2021-04/events/{id}:
+    $ref: route.events.yml#/id
+  /2021-04/events/{id}/categories:
+    $ref: route.events.yml#/categories
+  /2021-04/events/{id}/contributors:
+    $ref: route.events.yml#/contributors
+  /2021-04/events/{id}/multimediaDescriptions:
+    $ref: route.events.yml#/multimediaDescriptions
+  /2021-04/events/{id}/organizers:
+    $ref: route.events.yml#/organizers
+  /2021-04/events/{id}/publisher:
+    $ref: route.events.yml#/publisher
+  /2021-04/events/{id}/series:
+    $ref: route.events.yml#/series
+  /2021-04/events/{id}/sponsors:
+    $ref: route.events.yml#/sponsors
+  /2021-04/events/{id}/subEvents:
+    $ref: route.events.yml#/subEvents
+  /2021-04/events/{id}/venues:
+    $ref: route.events.yml#/venues
+    
+  # /2021-04/eventSeries:
+  #   $ref: route.eventSeries.yml#/base
+  # /2021-04/eventSeries/{id}:
+  #   $ref: route.eventSeries.yml#/id
+  # /2021-04/eventSeries/{id}/categories:
+  #   $ref: route.eventSeries.yml#/categories
+  # /2021-04/eventSeries/{id}/editions:
+  #   $ref: route.eventSeries.yml#/editions
+  # /2021-04/eventSeries/{id}/multimediaDescriptions:
+  #   $ref: route.eventSeries.yml#/multimediaDescriptions
+
+  /2021-04/features:
+    $ref: route.features.yml#/base
+  /2021-04/features/{id}:
+    $ref: route.features.yml#/id
+  /2021-04/features/{id}/children:
+    $ref: route.features.yml#/children
+  /2021-04/features/{id}/multimediaDescriptions:
+    $ref: route.features.yml#/multimediaDescriptions
+  /2021-04/features/{id}/parents:
+    $ref: route.features.yml#/parents
+    
+  /2021-04/lifts:
+    $ref: route.lifts.yml#/base
+  /2021-04/lifts/{id}:
+    $ref: route.lifts.yml#/id
+  /2021-04/lifts/{id}/categories:
+    $ref: route.lifts.yml#/categories
+  /2021-04/lifts/{id}/connections:
+    $ref: route.lifts.yml#/connections
+  /2021-04/lifts/{id}/multimediaDescriptions:
+    $ref: route.lifts.yml#/multimediaDescriptions
+    
+  # /2021-04/mediaObjects:
+  #   $ref: route.mediaObjects.yml#/base
+  # /2021-04/mediaObjects/{id}:
+  #   $ref: route.mediaObjects.yml#/id
+  # /2021-04/mediaObjects/{id}/categories:
+  #   $ref: route.mediaObjects.yml#/categories
+  # /2021-04/mediaObjects/{id}/multimediaDescriptions:
+  #   $ref: route.mediaObjects.yml#/copyrightOwner
+
+  /2021-04/mountainAreas:
+    $ref: route.mountainAreas.yml#/base
+  /2021-04/mountainAreas/{id}:
+    $ref: route.mountainAreas.yml#/id
+  /2021-04/mountainAreas/{id}/areaOwner:
+    $ref: route.mountainAreas.yml#/areaOwner
+  /2021-04/mountainAreas/{id}/categories:
+    $ref: route.mountainAreas.yml#/categories
+  /2021-04/mountainAreas/{id}/connections:
+    $ref: route.mountainAreas.yml#/connections
+  /2021-04/mountainAreas/{id}/lifts:
+    $ref: route.mountainAreas.yml#/lifts
+  /2021-04/mountainAreas/{id}/multimediaDescriptions:
+    $ref: route.mountainAreas.yml#/multimediaDescriptions
+  /2021-04/mountainAreas/{id}/skiSlopes:
+    $ref: route.mountainAreas.yml#/skiSlopes
+  /2021-04/mountainAreas/{id}/snowparks:
+    $ref: route.mountainAreas.yml#/snowparks
+  /2021-04/mountainAreas/{id}/subAreas:
+    $ref: route.mountainAreas.yml#/subAreas
+
+  /2021-04/skiSlopes:
+    $ref: route.skiSlopes.yml#/base
+  /2021-04/skiSlopes/{id}:
+    $ref: route.skiSlopes.yml#/id
+  /2021-04/skiSlopes/{id}/categories:
+    $ref: route.skiSlopes.yml#/categories
+  /2021-04/skiSlopes/{id}/connections:
+    $ref: route.skiSlopes.yml#/connections
+  /2021-04/skiSlopes/{id}/multimediaDescriptions:
+    $ref: route.skiSlopes.yml#/multimediaDescriptions
+    
+  /2021-04/snowparks:
+    $ref: route.snowparks.yml#/base
+  /2021-04/snowparks/{id}:
+    $ref: route.snowparks.yml#/id
+  /2021-04/snowparks/{id}/categories:
+    $ref: route.snowparks.yml#/categories
+  /2021-04/snowparks/{id}/connections:
+    $ref: route.snowparks.yml#/connections
+  /2021-04/snowparks/{id}/features:
+    $ref: route.snowparks.yml#/features
+  /2021-04/snowparks/{id}/multimediaDescriptions:
+    $ref: route.snowparks.yml#/multimediaDescriptions
+    
+  # /2021-04/venues:
+  #   $ref: route.venues.yml#/base
+  # /2021-04/venues/{id}:
+  #   $ref: route.venues.yml#/id
+  # /2021-04/venues/{id}/categories:
+  #   $ref: route.venues.yml#/categories
+  # /2021-04/venues/{id}/multimediaDescriptions:
+  #   $ref: route.venues.yml#/multimediaDescriptions

--- a/openapi/src/parameters/fields.yml
+++ b/openapi/src/parameters/fields.yml
@@ -4,16 +4,17 @@ fields:
     style: deepObject
     explode: true
     allowReserved: true
-    description: Selects which fields (i.e., attributes or relationships)
+    description: >
+      Selects which fields (i.e., attributes or relationships)
       should be present in returned resource. Each `fields` query must refer to
       a single resource type that can be returned in the endpoint (e.g.,
-      `fields[categories]=name,url`). If a selected resource type or field does
-      not exist in the endpoint, the server shall respond with `400 Bad
-      Request`.
+      `fields[categories]=name,url`). Notice that if you wish to use this
+      example in a request you must represent it as a JSON object due to the
+      supported serialization of objects in URLs: `{ "categories": "name,url" }`.
+      If a selected resource type or field does not exist in the endpoint, the
+      server shall respond with `400 Bad Request`.
     schema:
       type: object
       additionalProperties:
         type: string
-      example:
-        categories: name
-        mediaObjects: licenseType, copyrightOwner
+      example: {}

--- a/openapi/src/parameters/fields.yml
+++ b/openapi/src/parameters/fields.yml
@@ -1,0 +1,19 @@
+fields:
+    name: fields
+    in: query
+    style: deepObject
+    explode: true
+    allowReserved: true
+    description: Selects which fields (i.e., attributes or relationships)
+      should be present in returned resource. Each `fields` query must refer to
+      a single resource type that can be returned in the endpoint (e.g.,
+      `fields[categories]=name,url`). If a selected resource type or field does
+      not exist in the endpoint, the server shall respond with `400 Bad
+      Request`.
+    schema:
+      type: object
+      additionalProperties:
+        type: string
+      example:
+        categories: name
+        mediaObjects: licenseType, copyrightOwner

--- a/openapi/src/parameters/filter.yml
+++ b/openapi/src/parameters/filter.yml
@@ -1,0 +1,184 @@
+filter:
+  name: filter
+  in: query
+  style: deepObject
+  explode: true
+  allowReserved: true
+  description: Filters resources in the endpoint based on "label-specific" or
+    "simple generic" filters. Label-specific filters have their behavior and
+    syntax defined by the server (e.g., a filter for resources available in
+    desired languages, `filter[lang]=eng,ita,deu`). Simple generic filters
+    combine a field (among the fields in the resources present in `data`) and
+    a logical operand (e.g., filter resources with a last update value greater
+    than a certain date, `filter[lastUpdate][gt]=2021-04-01`). The operands
+    and their behavior is defined by the standard. Filters may refer to nested
+    fields (e.g., `filter[name.eng][exists]=true`). If the server is unable
+    process any filter, it shall respond with `400 Bad Request`.
+  schema:
+    type: object
+    additionalProperties:
+      anyOf:
+        - type: string
+        - type: object
+          additionalProperties:
+            type: string
+    example:
+      lang: eng,ita,deu
+      lastUpdate:
+        gt: '2021-04-01'
+filterActivities:
+  name: filter
+  in: query
+  style: deepObject
+  explode: true
+  allowReserved: true
+  description: >
+    Filters resources in the endpoint based on "label-specific" or
+    "simple generic" filters. The available filters are:
+      - `filter[lang]`: filters resources containing text data in the desired
+      languages (e.g., `filter[lang]=eng,ita,deu`). Receives comma-separated
+      ISO 639-3 languages tags.
+
+      - `filter[lastUpdate][gt]`: filters resources updated after a desired
+      date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601
+      date string.
+      
+      - `filter[lastUpdate][lt]`: filters resources updated before a desired
+      date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601
+      date string.
+
+      - `filter[categories][any]`: filters resources having any of the desired
+      categories (e.g., `filter[categories][any]=example:cat1,example:cat2`).
+      Receives comma-separated category ids.
+
+      - `filter[categories][all]`: filters resources having all of the desired
+      categories (e.g., `filter[categories][all]=example:cat1,example:cat2`).
+      Receives comma-separated category ids.
+
+      - `filter[geometries][near]`: filters resources whose geometries are near
+      a desired GPS point (e.g.,
+      `filter[geometries][near]=11.309245,46.862025,10000`). Receives three
+      comma-separated numbers in the following order: a longitude value, a
+      latitude value, and a proximity radius in meters.
+
+
+    If the server is unable process any filter, it shall respond with `400 Bad
+    Request`.
+  schema:
+    type: object
+    properties:
+      lang:
+        type: string
+      lastUpdate:
+        type: object
+        properties:
+          gt:
+            type: string
+          lt:
+            type: string
+      categories:
+        type: object
+        properties:
+          any:
+            type: string
+          all:
+            type: string
+      geometries:
+        type: object
+        properties:
+          near:
+            type: string
+    example:
+      lang: eng,ita,deu
+      lastUpdate:
+        gt: '2021-04-01'
+      categories:
+        any: 'example:category'
+      geometries:
+        near: 11.309245,46.862025,10000
+filterEvents:
+  name: filter
+  in: query
+  style: deepObject
+  explode: true
+  allowReserved: true
+  description: >
+    Filters resources in the endpoint based on "label-specific" or
+    "simple generic" filters. The available filters are:
+      - `filter[lang]`: filters resources containing text data in the desired
+      languages (e.g., `filter[lang]=eng,ita,deu`). Receives comma-separated
+      ISO 639-3 languages tags.
+
+      - `filter[lastUpdate][gt]`: filters resources updated after a desired
+      date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601
+      date string.
+      
+      - `filter[lastUpdate][lt]`: filters resources updated before a desired
+      date (e.g., `filter[lastUpdate][lt]=2021-04-01`). Receives an ISO 8601
+      date string.
+
+      - `filter[startDate][gt]`: filters events with a start date greater than a
+      desired date (e.g., `filter[startDate][gt]=2021-04-01`). Receives an ISO
+      8601 date string.
+      
+      - `filter[startDate][lt]`: filters events with a start date lower than a
+      desired date (e.g., `filter[startDate][lt]=2021-04-01`). Receives an ISO
+      8601 date string.
+
+      - `filter[endDate][gt]`: filters events with a end date greater than a
+      desired date (e.g., `filter[endDate][gt]=2021-04-01`). Receives an ISO
+      8601 date string.
+      
+      - `filter[endDate][lt]`: filters events with a end date lower than a
+      desired date (e.g., `filter[endDate][lt]=2021-04-01`). Receives an ISO
+      8601 date string.
+
+      - `filter[categories][any]`: filters resources having any of the desired
+      categories (e.g., `filter[categories][any]=example:cat1,example:cat2`).
+      Receives comma-separated category ids.
+
+      - `filter[categories][all]`: filters resources having all of the desired
+      categories (e.g., `filter[categories][all]=example:cat1,example:cat2`).
+      Receives comma-separated category ids.
+
+      - `filter[venues][near]`: filters resources whose venues' geometries are
+      near a desired GPS point (e.g.,
+      `filter[venues][near]=11.309245,46.862025,10000`). Receives three
+      comma-separated numbers in the following order: a longitude value, a
+      latitude value, and a proximity radius in meters.
+
+
+    If the server is unable process any filter, it shall respond with `400 Bad
+    Request`.
+  schema:
+    type: object
+    properties:
+      lang:
+        type: string
+      lastUpdate:
+        type: object
+        properties:
+          gt:
+            type: string
+          lt:
+            type: string
+      categories:
+        type: object
+        properties:
+          any:
+            type: string
+          all:
+            type: string
+      geometries:
+        type: object
+        properties:
+          near:
+            type: string
+    example:
+      lang: eng,ita,deu
+      lastUpdate:
+        gt: '2021-04-01'
+      categories:
+        any: 'example:category'
+      geometries:
+        near: 11.309245,46.862025,10000

--- a/openapi/src/parameters/filter.yml
+++ b/openapi/src/parameters/filter.yml
@@ -22,10 +22,6 @@ filter:
         - type: object
           additionalProperties:
             type: string
-    example:
-      lang: eng,ita,deu
-      lastUpdate:
-        gt: '2021-04-01'
 filterActivities:
   name: filter
   in: query
@@ -61,7 +57,10 @@ filterActivities:
       comma-separated numbers in the following order: a longitude value, a
       latitude value, and a proximity radius in meters.
 
-
+    Notice that if you wish to use one of these examples in a request you must
+    represent them as a JSON objects due to the supported serialization of
+    objects in URLs: for label-specific filters, `{ "lang": "eng,ita,deu" }`;
+    and for simple generic filters, `{ "lastUpdate": { "gt": "2021-04-01" } }`.
     If the server is unable process any filter, it shall respond with `400 Bad
     Request`.
   schema:
@@ -88,14 +87,7 @@ filterActivities:
         properties:
           near:
             type: string
-    example:
-      lang: eng,ita,deu
-      lastUpdate:
-        gt: '2021-04-01'
-      categories:
-        any: 'example:category'
-      geometries:
-        near: 11.309245,46.862025,10000
+    example: {}
 filterEvents:
   name: filter
   in: query
@@ -147,7 +139,10 @@ filterEvents:
       comma-separated numbers in the following order: a longitude value, a
       latitude value, and a proximity radius in meters.
 
-
+    Notice that if you wish to use one of these examples in a request you must
+    represent them as a JSON objects due to the supported serialization of
+    objects in URLs: for label-specific filters, `{ "lang": "eng,ita,deu" }`;
+    and for simple generic filters, `{ "lastUpdate": { "gt": "2021-04-01" } }`.
     If the server is unable process any filter, it shall respond with `400 Bad
     Request`.
   schema:
@@ -174,11 +169,4 @@ filterEvents:
         properties:
           near:
             type: string
-    example:
-      lang: eng,ita,deu
-      lastUpdate:
-        gt: '2021-04-01'
-      categories:
-        any: 'example:category'
-      geometries:
-        near: 11.309245,46.862025,10000
+    example: {}

--- a/openapi/src/parameters/id.yml
+++ b/openapi/src/parameters/id.yml
@@ -1,0 +1,8 @@
+id:
+  name: id
+  in: path
+  description: Requests for a resource of matching `{id}` and resource type.
+  required: true
+  schema:
+    type: string
+    minLength: 1

--- a/openapi/src/parameters/include.yml
+++ b/openapi/src/parameters/include.yml
@@ -1,0 +1,15 @@
+include:
+  name: include
+  in: query
+  style: form
+  explode: false
+  description: Includes resources present in selected relationships in the
+    `included` array of the response. Only relationships of objects in the
+    `data` field can be selected. Relationship names must be separated with a
+    comma (e.g., `include=categories,multimediaDescriptions`). If a selected
+    relationship does not exist among the relationships of resources in `data`,
+    the server shall respond with `400 Bad Request`.
+  schema:
+    type: string
+    minLength: 1
+    pattern: (\w|-)+(,(\w|-)+)*

--- a/openapi/src/parameters/page.yml
+++ b/openapi/src/parameters/page.yml
@@ -1,0 +1,50 @@
+page:
+  name: page
+  in: query
+  style: deepObject
+  explode: true
+  allowReserved: true
+  description: Allows navigating through paginated resources by specifying the
+    desired page number and/or the desired page size. For example, the query
+    `page[number]=1&page[size]=10` requests the first page of an endpoint
+    providing 10 resources per request (page of size 10). Requests may not
+    specify page size or number, in which case the server shall use default
+    values.
+  schema:
+    type: object
+    properties:
+      number:
+        type: integer
+        minimum: 1
+      size:
+        type: integer
+        minimum: 1
+    example:
+      number: 1
+      size: 10
+pagesize:
+  name: page[size]
+  in: query
+  style: form
+  explode: true
+  allowReserved: true
+  description: Sets the page size of a paginated endpoint, i.e., the maximum
+    number of resources to be returned in a single request. If not specified,
+    the server shall set a default value (e.g., `10`).
+  schema:
+    type: integer
+    minimum: 1
+    example: 10
+pagenumber:
+  name: page[number]
+  in: query
+  style: form
+  explode: true
+  allowReserved: true
+  description: Sets the page number to be returned in the request. If the
+    requested page is greater than the total number of pages, the server shall
+    return respond with status code `404 Not Found`.
+  schema:
+    type: integer
+    minimum: 1
+    example: 1

--- a/openapi/src/parameters/random.yml
+++ b/openapi/src/parameters/random.yml
@@ -4,11 +4,10 @@ random:
   style: form
   explode: false
   description: Requests for resources to be retrieved in a pseudo-random
-    sequence from a provided seed (e.g., `random=0`). The server shall provide
-    consistent pagination over the same seed value. If a request includes both
-    `random` and `sort` requests, the server shall respond with `400 Bad
-    Request`.
+    sequence from a provided seed (e.g., `random=0`) which must be a number
+    between 1 and 50. The server shall provide consistent pagination over the
+    same seed value. If a request includes both `random` and `sort` requests,
+    the server shall respond with `400 Bad Request`.
   schema:
     type: string
     minLength: 1
-    example: 10

--- a/openapi/src/parameters/random.yml
+++ b/openapi/src/parameters/random.yml
@@ -1,0 +1,14 @@
+random:
+  name: random
+  in: query
+  style: form
+  explode: false
+  description: Requests for resources to be retrieved in a pseudo-random
+    sequence from a provided seed (e.g., `random=0`). The server shall provide
+    consistent pagination over the same seed value. If a request includes both
+    `random` and `sort` requests, the server shall respond with `400 Bad
+    Request`.
+  schema:
+    type: string
+    minLength: 1
+    example: 10

--- a/openapi/src/parameters/search.yml
+++ b/openapi/src/parameters/search.yml
@@ -10,4 +10,3 @@ search:
   schema:
     type: string
     minimum: 1
-    example: bozen

--- a/openapi/src/parameters/search.yml
+++ b/openapi/src/parameters/search.yml
@@ -1,0 +1,13 @@
+search:
+  name: search[name]
+  in: query
+  style: form
+  explode: true
+  allowReserved: true
+  description: >
+    Searches resources containing a desired substring in their names, regardless
+    of language or case (e.g., `search[name]=bozen`).
+  schema:
+    type: string
+    minimum: 1
+    example: bozen

--- a/openapi/src/parameters/sort.yml
+++ b/openapi/src/parameters/sort.yml
@@ -16,4 +16,3 @@ sort:
     type: string
     minLength: 1
     pattern: (\w|-)+(,(\w|-)+)*
-    example: startDate

--- a/openapi/src/parameters/sort.yml
+++ b/openapi/src/parameters/sort.yml
@@ -1,0 +1,19 @@
+sort:
+  name: sort
+  in: query
+  style: form
+  explode: false
+  description: Requests for retrieved resources to be sorted by the value some
+    selected field. Sorting requests may be in ascending (e.g.,
+    `sort=startDate`) or descending order (e.g., `sort=-startDate`) by prefixing
+    the field name with a MINUS (U+002D) character. Sorted requests may also
+    take multiple fields as input as well as nested fields (e).g.,
+    `sort=-startDate,name.eng`). If a request includes both `random` and `sort`
+    requests, the server shall respond with `400 Bad Request`. If a server is
+    unable to use any selected fields to sort resources, it shall respond with
+    `400 Bad Request`.
+  schema:
+    type: string
+    minLength: 1
+    pattern: (\w|-)+(,(\w|-)+)*
+    example: startDate

--- a/openapi/src/route.agents.yml
+++ b/openapi/src/route.agents.yml
@@ -1,0 +1,81 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `agents`.
+    tags:
+      - Agents
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      # - $ref: parameters/filter.yml#/filter
+      # - $ref: parameters/search.yml#/search
+      # - $ref: parameters/sort.yml#/sort
+      # - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/agents.json
+id:
+  get:
+    description: Retrieves a single resource type `agents` with a matching
+      `{id}`.
+    tags:
+      - Agents
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/agents.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `agents`.
+    tags:
+      - Agents
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/agents.categories.json
+      '404':
+        description: 404 Not Found
+      # TODO: review if relationships should also return status code 410 if the {id} resource is deleted
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `agents`.
+    tags:
+      - Agents
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/agents.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.base.yml
+++ b/openapi/src/route.base.yml
@@ -1,0 +1,28 @@
+base:
+  get:
+    operationId: /
+    description: Retrieves links to the  implemented versions of the
+      AlpineBits DestinationData standard.
+    tags:
+      - Base
+    responses:
+      '200':
+        description: OK
+        content:
+          application/vnd.api+json:
+            example:
+              $ref: examples/base.json
+2021-04:
+  get:
+    operationId: /2021-04
+    description: Retrieves links to the base endpoints of available resource 
+      types.
+    tags:
+      - Base
+    responses:
+      '200':
+        description: OK
+        content:
+          application/vnd.api+json:
+            example:
+              $ref: examples/2021-04.json

--- a/openapi/src/route.categories.yml
+++ b/openapi/src/route.categories.yml
@@ -1,0 +1,99 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `categories`.
+    tags:
+      - Categories
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      # - $ref: parameters/filter.yml#/filter
+      # - $ref: parameters/search.yml#/search
+      # - $ref: parameters/sort.yml#/sort
+      # - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/categories.json
+id:
+  get:
+    description: Retrieves a single resource type `categories` with a matching
+      `{id}`.
+    tags:
+      - Categories
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/categories.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+children:
+  get:
+    description: Retrieves the resources in the relationship `children` of a
+      resource of type `categories`.
+    tags:
+      - Categories
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/categories.children.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `categories`.
+    tags:
+      - Categories
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/categories.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found`
+parents:
+  get:
+    description: Retrieves the resources in the relationship `parents` of a
+      resource of type `categories`.
+    tags:
+      - Categories
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/categories.parents.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.eventSeries.yml
+++ b/openapi/src/route.eventSeries.yml
@@ -1,0 +1,99 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `eventSeries`.
+    tags:
+      - Event Series
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      - $ref: parameters/filter.yml#/filter
+      - $ref: parameters/search.yml#/search
+      - $ref: parameters/sort.yml#/sort
+      - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/eventSeries.json
+id:
+  get:
+    description: Retrieves a single resource type `eventSeries` with a matching
+      `{id}`.
+    tags:
+      - Event Series
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/eventSeries.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `eventSeries`.
+    tags:
+      - Event Series
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/eventSeries.categories.json
+      '404':
+        description: 404 Not Found
+editions:
+  get:
+    description: Retrieves the resources in the relationship `editions` of a
+      resource of type `eventSeries`.
+    tags:
+      - Event Series
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/eventSeries.editions.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `eventSeries`.
+    tags:
+      - Event Series
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/eventSeries.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.events.yml
+++ b/openapi/src/route.events.yml
@@ -1,0 +1,213 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      - $ref: parameters/filter.yml#/filterEvents
+      - $ref: parameters/search.yml#/search
+      - $ref: parameters/sort.yml#/sort
+      - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.json
+id:
+  get:
+    description: Retrieves a single resource type `events` with a matching
+      `{id}`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.categories.json
+      '404':
+        description: 404 Not Found
+contributors:
+  get:
+    description: Retrieves the resources in the relationship `contributors` of a
+      resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.contributors.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found
+organizers:
+  get:
+    description: Retrieves the resources in the relationship `organizers` of a
+      resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.organizers.json
+      '404':
+        description: 404 Not Found
+publisher:
+  get:
+    description: Retrieves the resources in the relationship `publisher` of a
+      resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.publisher.json
+      '404':
+        description: 404 Not Found
+series:
+  get:
+    description: Retrieves the resources in the relationship `series` of a
+      resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.series.json
+      '404':
+        description: 404 Not Found
+sponsors:
+  get:
+    description: Retrieves the resources in the relationship `sponsors` of a
+      resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.sponsors.json
+      '404':
+        description: 404 Not Found
+subEvents:
+  get:
+    description: Retrieves the resources in the relationship `subEvents` of a
+      resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.subEvents.json
+      '404':
+        description: 404 Not Found
+venues:
+  get:
+    description: Retrieves the resources in the relationship `venues` of a
+      resource of type `events`.
+    tags:
+      - Events
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/events.venues.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.features.yml
+++ b/openapi/src/route.features.yml
@@ -1,0 +1,99 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `features`.
+    tags:
+      - Features
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      # - $ref: parameters/filter.yml#/filter
+      # - $ref: parameters/search.yml#/search
+      # - $ref: parameters/sort.yml#/sort
+      # - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/features.json
+id:
+  get:
+    description: Retrieves a single resource type `features` with a matching
+      `{id}`.
+    tags:
+      - Features
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/features.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+children:
+  get:
+    description: Retrieves the resources in the relationship `children` of a
+      resource of type `features`.
+    tags:
+      - Features
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/features.children.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `features`.
+    tags:
+      - Features
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/features.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found`
+parents:
+  get:
+    description: Retrieves the resources in the relationship `parents` of a
+      resource of type `features`.
+    tags:
+      - Features
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/features.parents.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.lifts.yml
+++ b/openapi/src/route.lifts.yml
@@ -1,0 +1,99 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `lifts`.
+    tags:
+      - Lifts
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      - $ref: parameters/filter.yml#/filterActivities
+      - $ref: parameters/search.yml#/search
+      # - $ref: parameters/sort.yml#/sort
+      # - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/lifts.json
+id:
+  get:
+    description: Retrieves a single resource type `lifts` with a matching
+      `{id}`.
+    tags:
+      - Lifts
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/lifts.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `lifts`.
+    tags:
+      - Lifts
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/lifts.categories.json
+      '404':
+        description: 404 Not Found
+connections:
+  get:
+    description: Retrieves the resources in the relationship `connections` of a
+      resource of type `lifts`.
+    tags:
+      - Lifts
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/lifts.connections.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `lifts`.
+    tags:
+      - Lifts
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/lifts.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.mediaObjects.yml
+++ b/openapi/src/route.mediaObjects.yml
@@ -1,0 +1,80 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `mediaObjects`.
+    tags:
+      - Media Objects
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      - $ref: parameters/filter.yml#/filter
+      - $ref: parameters/search.yml#/search
+      - $ref: parameters/sort.yml#/sort
+      - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mediaObjects.json
+id:
+  get:
+    description: Retrieves a single resource type `mediaObjects` with a matching
+      `{id}`.
+    tags:
+      - Media Objects
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mediaObjects.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `mediaObjects`.
+    tags:
+      - Media Objects
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mediaObjects.categories.json
+      '404':
+        description: 404 Not Found
+copyrightOwner:
+  get:
+    description: Retrieves the resources in the relationship
+      `copyrightOwner` of a resource of type `mediaObjects`.
+    tags:
+      - Media Objects
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mediaObjects.copyrightOwner.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.mountainAreas.yml
+++ b/openapi/src/route.mountainAreas.yml
@@ -1,0 +1,194 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      # - $ref: parameters/filter.yml#/filter
+      # - $ref: parameters/search.yml#/search
+      # - $ref: parameters/sort.yml#/sort
+      # - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.json
+id:
+  get:
+    description: Retrieves a single resource type `mountainAreas` with a matching
+      `{id}`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+areaOwner:
+  get:
+    description: Retrieves the resources in the relationship `areaOwner` of a
+      resource of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.areaOwner.json
+      '404':
+        description: 404 Not Found
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.categories.json
+      '404':
+        description: 404 Not Found
+connections:
+  get:
+    description: Retrieves the resources in the relationship `connections` of a
+      resource of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.connections.json
+      '404':
+        description: 404 Not Found
+lifts:
+  get:
+    description: Retrieves the resources in the relationship `lifts` of a
+      resource of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.lifts.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found
+skiSlopes:
+  get:
+    description: Retrieves the resources in the relationship `skiSlopes` of a
+      resource of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.skiSlopes.json
+      '404':
+        description: 404 Not Found
+snowparks:
+  get:
+    description: Retrieves the resources in the relationship `snowparks` of a
+      resource of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.snowparks.json
+      '404':
+        description: 404 Not Found
+subAreas:
+  get:
+    description: Retrieves the resources in the relationship `subAreas` of a
+      resource of type `mountainAreas`.
+    tags:
+      - Mountain Areas
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/mountainAreas.subAreas.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.skiSlopes.yml
+++ b/openapi/src/route.skiSlopes.yml
@@ -1,0 +1,99 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `skiSlopes`.
+    tags:
+      - Ski Slopes
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      - $ref: parameters/filter.yml#/filterActivities
+      - $ref: parameters/search.yml#/search
+      # - $ref: parameters/sort.yml#/sort
+      # - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/skiSlopes.json
+id:
+  get:
+    description: Retrieves a single resource type `skiSlopes` with a matching
+      `{id}`.
+    tags:
+      - Ski Slopes
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/skiSlopes.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `skiSlopes`.
+    tags:
+      - Ski Slopes
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/skiSlopes.categories.json
+      '404':
+        description: 404 Not Found
+connections:
+  get:
+    description: Retrieves the resources in the relationship `connections` of a
+      resource of type `skiSlopes`.
+    tags:
+      - Ski Slopes
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/skiSlopes.connections.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `skiSlopes`.
+    tags:
+      - Ski Slopes
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/skiSlopes.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.snowparks.yml
+++ b/openapi/src/route.snowparks.yml
@@ -1,0 +1,118 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `snowparks`.
+    tags:
+      - Snowparks
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      - $ref: parameters/filter.yml#/filterActivities
+      - $ref: parameters/search.yml#/search
+      # - $ref: parameters/sort.yml#/sort
+      # - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/snowparks.json
+id:
+  get:
+    description: Retrieves a single resource type `snowparks` with a matching
+      `{id}`.
+    tags:
+      - Snowparks
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/snowparks.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `snowparks`.
+    tags:
+      - Snowparks
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/snowparks.categories.json
+      '404':
+        description: 404 Not Found
+connections:
+  get:
+    description: Retrieves the resources in the relationship `connections` of a
+      resource of type `snowparks`.
+    tags:
+      - Snowparks
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/snowparks.connections.json
+      '404':
+        description: 404 Not Found
+features:
+  get:
+    description: Retrieves the resources in the relationship `features` of a
+      resource of type `snowparks`.
+    tags:
+      - Snowparks
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/snowparks.features.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `snowparks`.
+    tags:
+      - Snowparks
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/snowparks.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found

--- a/openapi/src/route.venues.yml
+++ b/openapi/src/route.venues.yml
@@ -1,0 +1,80 @@
+base:
+  get:
+    description: Retrieves a collection of resources of type `venues`.
+    tags:
+      - Venues
+    parameters:
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+      - $ref: parameters/page.yml#/pagesize
+      - $ref: parameters/page.yml#/pagenumber
+      # - $ref: parameters/filter.yml#/filter
+      # - $ref: parameters/search.yml#/search
+      # - $ref: parameters/sort.yml#/sort
+      # - $ref: parameters/random.yml#/random
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/venues.json
+id:
+  get:
+    description: Retrieves a single resource type `venues` with a matching
+      `{id}`.
+    tags:
+      - Venues
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/venues.id.json
+      '404':
+        description: 404 Not Found
+      '410':
+        description: 410 Gone
+categories:
+  get:
+    description: Retrieves the resources in the relationship `categories` of a
+      resource of type `venues`.
+    tags:
+      - Venues
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/venues.categories.json
+      '404':
+        description: 404 Not Found
+multimediaDescriptions:
+  get:
+    description: Retrieves the resources in the relationship
+      `multimediaDescriptions` of a resource of type `venues`.
+    tags:
+      - Venues
+    parameters:
+      - $ref: parameters/id.yml#/id
+      - $ref: parameters/include.yml#/include
+      - $ref: parameters/fields.yml#/fields
+    responses:
+      '200':
+        description: OK
+        content:
+            application/vnd.api+json:
+              example:
+                $ref: examples/venues.multimediaDescriptions.json
+      '404':
+        description: 404 Not Found

--- a/src/index.json
+++ b/src/index.json
@@ -3,6 +3,7 @@
   "links": {
     "self": "${URL_BASE}",
     "1.0": "${URL_BASE}/1.0",
-    "2021-04": "${URL_BASE}/2021-04"
+    "2021-04": "${URL_BASE}/2021-04",
+    "swagger": "${URL_SWAGGER}"
   }
 }

--- a/src/specification.json
+++ b/src/specification.json
@@ -600,7 +600,7 @@
             "style": "deepObject",
             "explode": true,
             "allowReserved": true,
-            "description": "Filters resources in the endpoint based on \"label-specific\" or \"simple generic\" filters. The available filters are:\n  - `filter[lang]`: filters resources containing text data in the desired\n  languages (e.g., `filter[lang]=eng,ita,deu`). Receives comma-separated\n  ISO 639-3 languages tags.\n\n  - `filter[lastUpdate][gt]`: filters resources updated after a desired\n  date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601\n  date string.\n  \n  - `filter[lastUpdate][lt]`: filters resources updated before a desired\n  date (e.g., `filter[lastUpdate][lt]=2021-04-01`). Receives an ISO 8601\n  date string.\n\n  - `filter[startDate][gt]`: filters events with a start date greater than a\n  desired date (e.g., `filter[startDate][gt]=2021-04-01`). Receives an ISO\n  8601 date string.\n  \n  - `filter[startDate][lt]`: filters events with a start date lower than a\n  desired date (e.g., `filter[startDate][lt]=2021-04-01`). Receives an ISO\n  8601 date string.\n\n  - `filter[endDate][gt]`: filters events with a end date greater than a\n  desired date (e.g., `filter[endDate][gt]=2021-04-01`). Receives an ISO\n  8601 date string.\n  \n  - `filter[endDate][lt]`: filters events with a end date lower than a\n  desired date (e.g., `filter[endDate][lt]=2021-04-01`). Receives an ISO\n  8601 date string.\n\n  - `filter[categories][any]`: filters resources having any of the desired\n  categories (e.g., `filter[categories][any]=example:cat1,example:cat2`).\n  Receives comma-separated category ids.\n\n  - `filter[categories][all]`: filters resources having all of the desired\n  categories (e.g., `filter[categories][all]=example:cat1,example:cat2`).\n  Receives comma-separated category ids.\n\n  - `filter[venues][near]`: filters resources whose venues' geometries are\n  near a desired GPS point (e.g.,\n  `filter[venues][near]=11.309245,46.862025,10000`). Receives three\n  comma-separated numbers in the following order: a longitude value, a\n  latitude value, and a proximity radius in meters.\n\n\nIf the server is unable process any filter, it shall respond with `400 Bad Request`.\n",
+            "description": "Filters resources in the endpoint based on \"label-specific\" or \"simple generic\" filters. The available filters are:\n  - `filter[lang]`: filters resources containing text data in the desired\n  languages (e.g., `filter[lang]=eng,ita,deu`). Receives comma-separated\n  ISO 639-3 languages tags.\n\n  - `filter[lastUpdate][gt]`: filters resources updated after a desired\n  date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601\n  date string.\n  \n  - `filter[lastUpdate][lt]`: filters resources updated before a desired\n  date (e.g., `filter[lastUpdate][lt]=2021-04-01`). Receives an ISO 8601\n  date string.\n\n  - `filter[startDate][gt]`: filters events with a start date greater than a\n  desired date (e.g., `filter[startDate][gt]=2021-04-01`). Receives an ISO\n  8601 date string.\n  \n  - `filter[startDate][lt]`: filters events with a start date lower than a\n  desired date (e.g., `filter[startDate][lt]=2021-04-01`). Receives an ISO\n  8601 date string.\n\n  - `filter[endDate][gt]`: filters events with a end date greater than a\n  desired date (e.g., `filter[endDate][gt]=2021-04-01`). Receives an ISO\n  8601 date string.\n  \n  - `filter[endDate][lt]`: filters events with a end date lower than a\n  desired date (e.g., `filter[endDate][lt]=2021-04-01`). Receives an ISO\n  8601 date string.\n\n  - `filter[categories][any]`: filters resources having any of the desired\n  categories (e.g., `filter[categories][any]=example:cat1,example:cat2`).\n  Receives comma-separated category ids.\n\n  - `filter[categories][all]`: filters resources having all of the desired\n  categories (e.g., `filter[categories][all]=example:cat1,example:cat2`).\n  Receives comma-separated category ids.\n\n  - `filter[venues][near]`: filters resources whose venues' geometries are\n  near a desired GPS point (e.g.,\n  `filter[venues][near]=11.309245,46.862025,10000`). Receives three\n  comma-separated numbers in the following order: a longitude value, a\n  latitude value, and a proximity radius in meters.\n\nNotice that if you wish to use one of these examples in a request you must represent them as a JSON objects due to the supported serialization of objects in URLs: for label-specific filters, `{ \"lang\": \"eng,ita,deu\" }`; and for simple generic filters, `{ \"lastUpdate\": { \"gt\": \"2021-04-01\" } }`. If the server is unable process any filter, it shall respond with `400 Bad Request`.\n",
             "schema": {
               "type": "object",
               "properties": {
@@ -637,18 +637,6 @@
                     }
                   }
                 }
-              },
-              "example": {
-                "lang": "eng,ita,deu",
-                "lastUpdate": {
-                  "gt": "2021-04-01"
-                },
-                "categories": {
-                  "any": "example:category"
-                },
-                "geometries": {
-                  "near": "11.309245,46.862025,10000"
-                }
               }
             }
           },
@@ -664,8 +652,7 @@
             "schema": {
               "type": "string",
               "minLength": 1,
-              "pattern": "(\\w|-)+(,(\\w|-)+)*",
-              "example": "startDate"
+              "pattern": "(\\w|-)+(,(\\w|-)+)*"
             }
           },
           {
@@ -676,8 +663,7 @@
             "description": "Requests for resources to be retrieved in a pseudo-random sequence from a provided seed (e.g., `random=0`). The server shall provide consistent pagination over the same seed value. If a request includes both `random` and `sort` requests, the server shall respond with `400 Bad Request`.",
             "schema": {
               "type": "string",
-              "minLength": 1,
-              "example": 10
+              "minLength": 1
             }
           }
         ],
@@ -2766,15 +2752,11 @@
             "style": "deepObject",
             "explode": true,
             "allowReserved": true,
-            "description": "Selects which fields (i.e., attributes or relationships) should be present in returned resource. Each `fields` query must refer to a single resource type that can be returned in the endpoint (e.g., `fields[categories]=name,url`). If a selected resource type or field does not exist in the endpoint, the server shall respond with `400 Bad Request`.",
+            "description": "Selects which fields (i.e., attributes or relationships) should be present in returned resource. Each `fields` query must refer to a single resource type that can be returned in the endpoint (e.g., `fields[categories]=name,url`). Notice that if you wish to use this example in a request you must represent it as a JSON object due to the supported serialization of objects in URLs: `{ \"categories\": \"name,url\" }`. If a selected resource type or field does not exist in the endpoint, the server shall respond with `400 Bad Request`.\n",
             "schema": {
               "type": "object",
               "additionalProperties": {
                 "type": "string"
-              },
-              "example": {
-                "categories": "name",
-                "mediaObjects": "licenseType, copyrightOwner"
               }
             }
           },
@@ -2810,7 +2792,7 @@
             "style": "deepObject",
             "explode": true,
             "allowReserved": true,
-            "description": "Filters resources in the endpoint based on \"label-specific\" or \"simple generic\" filters. The available filters are:\n  - `filter[lang]`: filters resources containing text data in the desired\n  languages (e.g., `filter[lang]=eng,ita,deu`). Receives comma-separated\n  ISO 639-3 languages tags.\n\n  - `filter[lastUpdate][gt]`: filters resources updated after a desired\n  date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601\n  date string.\n  \n  - `filter[lastUpdate][lt]`: filters resources updated before a desired\n  date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601\n  date string.\n\n  - `filter[categories][any]`: filters resources having any of the desired\n  categories (e.g., `filter[categories][any]=example:cat1,example:cat2`).\n  Receives comma-separated category ids.\n\n  - `filter[categories][all]`: filters resources having all of the desired\n  categories (e.g., `filter[categories][all]=example:cat1,example:cat2`).\n  Receives comma-separated category ids.\n\n  - `filter[geometries][near]`: filters resources whose geometries are near\n  a desired GPS point (e.g.,\n  `filter[geometries][near]=11.309245,46.862025,10000`). Receives three\n  comma-separated numbers in the following order: a longitude value, a\n  latitude value, and a proximity radius in meters.\n\n\nIf the server is unable process any filter, it shall respond with `400 Bad Request`.\n",
+            "description": "Filters resources in the endpoint based on \"label-specific\" or \"simple generic\" filters. The available filters are:\n  - `filter[lang]`: filters resources containing text data in the desired\n  languages (e.g., `filter[lang]=eng,ita,deu`). Receives comma-separated\n  ISO 639-3 languages tags.\n\n  - `filter[lastUpdate][gt]`: filters resources updated after a desired\n  date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601\n  date string.\n  \n  - `filter[lastUpdate][lt]`: filters resources updated before a desired\n  date (e.g., `filter[lastUpdate][gt]=2021-04-01`). Receives an ISO 8601\n  date string.\n\n  - `filter[categories][any]`: filters resources having any of the desired\n  categories (e.g., `filter[categories][any]=example:cat1,example:cat2`).\n  Receives comma-separated category ids.\n\n  - `filter[categories][all]`: filters resources having all of the desired\n  categories (e.g., `filter[categories][all]=example:cat1,example:cat2`).\n  Receives comma-separated category ids.\n\n  - `filter[geometries][near]`: filters resources whose geometries are near\n  a desired GPS point (e.g.,\n  `filter[geometries][near]=11.309245,46.862025,10000`). Receives three\n  comma-separated numbers in the following order: a longitude value, a\n  latitude value, and a proximity radius in meters.\n\nNotice that if you wish to use one of these examples in a request you must represent them as a JSON objects due to the supported serialization of objects in URLs: for label-specific filters, `{ \"lang\": \"eng,ita,deu\" }`; and for simple generic filters, `{ \"lastUpdate\": { \"gt\": \"2021-04-01\" } }`. If the server is unable process any filter, it shall respond with `400 Bad Request`.\n",
             "schema": {
               "type": "object",
               "properties": {
@@ -2847,18 +2829,6 @@
                     }
                   }
                 }
-              },
-              "example": {
-                "lang": "eng,ita,deu",
-                "lastUpdate": {
-                  "gt": "2021-04-01"
-                },
-                "categories": {
-                  "any": "example:category"
-                },
-                "geometries": {
-                  "near": "11.309245,46.862025,10000"
-                }
               }
             }
           },
@@ -2871,8 +2841,7 @@
             "description": "Searches resources containing a desired substring in their names, regardless of language or case (e.g., `search[name]=bozen`).\n",
             "schema": {
               "type": "string",
-              "minimum": 1,
-              "example": "bozen"
+              "minimum": 1
             }
           }
         ],


### PR DESCRIPTION
This PR adds the OpenAPI specification for the reference server. This specification is intended to be consumed by the ODH's Swagger server.

The OpenAPI specification is in the `./openapi` folder as a NodeJS project. The only commands necessary to be ran, if integrated to a workflow, are (from inside the `./openapi` folder):

```
npm install              # installs project dependencies
npm run bundle      # bundles the various YAML files into a single JSON file
```

The generated JSON file is stored as `./src/specification.json`.

Additionally, this PR also adds a link field called `"swagger"` to the file `./src/index.json`. Please update the link in the `.env` file with the actual URL for the Swagger documentation of the reference server as this PR uses the link to a private GitHub account. The final URL may be something like `https://swagger.opendatahub.bz.it/destinationdata`, for example.